### PR TITLE
Mesh network diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "chai-subset": "^1.6.0",
     "documentation": "^5.3.5",
     "mocha": "^4.0.1",
     "mocha-sinon": "^2.0.0",

--- a/src/device.js
+++ b/src/device.js
@@ -65,7 +65,7 @@ export class Device extends DeviceBase {
    * @return {Promise}
    */
   getSerialNumber() {
-    return this.sendRequest(RequestType.GET_SERIAL_NUMBER);
+    return this.sendRequest(Request.GET_SERIAL_NUMBER);
   }
 
   /**

--- a/src/device.js
+++ b/src/device.js
@@ -60,6 +60,15 @@ class RequestSender {
  */
 export class Device extends DeviceBase {
   /**
+   * Get device serial number
+   *
+   * @return {Promise}
+   */
+  getSerialNumber() {
+    return this.sendRequest(RequestType.GET_SERIAL_NUMBER);
+  }
+
+  /**
    * Perform the system reset.
    *
    * @return {Promise}

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -27,7 +27,8 @@ export const DiagnosticType = fromProtobufEnum(proto.mesh.DiagnosticType, {
   SUPPLY_VOLTAGE: 'SUPPLY_VOLTAGE',
   CHILD_TABLE: 'CHILD_TABLE',
   CHANNEL_PAGES: 'CHANNEL_PAGES',
-  TYPE_LIST: 'TYPE_LIST',
+  // NOTE: it's not possible to query this diagnostic TLV
+  // TYPE_LIST: 'TYPE_LIST',
   MAX_CHILD_TIMEOUT: 'MAX_CHILD_TIMEOUT'
 });
 

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -230,9 +230,13 @@ export const MeshDevice = base => class extends base {
       queryChildren: false,
       diagnosticTypes: ['RLOC']
   }) {
-    return this.sendRequest(RequestType.MESH_GET_NETWORK_DIAGNOSTICS, {
+    if (opts.queryChildren && !opts.diagnosticTypes.includes('CHILD_TABLE')) {
+      opts.diagnosticTypes.push('CHILD_TABLE');
+    }
+    return this.sendProtobufRequest(RequestType.GET_NETWORK_DIAGNOSTICS, {
       flags: opts.queryChildren ? proto.mesh.GetNetworkDiagnosticsRequest.Flags['QUERY_CHILDREN'] : 0,
-      diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf)
+      diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf),
+      timeout: timeout
     });
   }
 }

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -246,7 +246,7 @@ export const MeshDevice = base => class extends base {
       flags |= proto.mesh.GetNetworkDiagnosticsRequest.Flags['RESOLVE_DEVICE_ID'];
     }
 
-    return this.sendRequest(Request.GET_NETWORK_DIAGNOSTICS, {
+    return this.sendRequest(Request.MESH_GET_NETWORK_DIAGNOSTICS, {
       flags: flags,
       diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf),
       timeout: opts.timeout

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -226,11 +226,13 @@ export const MeshDevice = base => class extends base {
    * @param {Object} opts Request options
    * @return {Promise}
    */
-  async getNetworkDiagnostics(opts = {
+  async getNetworkDiagnostics(
+    opts = {
       timeout: DIAGNOSTIC_DEFAULT_TIMEOUT,
       queryChildren: false,
-      diagnosticTypes: ['RLOC']
-  }) {
+      diagnosticTypes: ["RLOC"]
+    }
+  ) {
     if (opts.queryChildren && !opts.diagnosticTypes.includes('CHILD_TABLE')) {
       opts.diagnosticTypes.push('CHILD_TABLE');
     }
@@ -244,10 +246,10 @@ export const MeshDevice = base => class extends base {
       flags |= proto.mesh.GetNetworkDiagnosticsRequest.Flags['RESOLVE_DEVICE_ID'];
     }
 
-    return this.sendRequest(RequestType.GET_NETWORK_DIAGNOSTICS, {
+    return this.sendRequest(Request.GET_NETWORK_DIAGNOSTICS, {
       flags: flags,
       diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf),
-      timeout: timeout
+      timeout: opts.timeout
     });
   }
 }

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -11,6 +11,28 @@ const MAX_NETWORK_NAME_LENGTH = 16;
 const MIN_NETWORK_PASSWORD_LENGTH = 6;
 const MAX_NETWORK_PASSWORD_LENGTH = 255;
 
+export const DiagnosticType = fromProtobufEnum(proto.mesh.DiagnosticType, {
+  MAC_EXTENDED_ADDRESS: 'MAC_EXTENDED_ADDRESS',
+  RLOC: 'RLOC',
+  MAC_ADDRESS: 'MAC_ADDRESS',
+  MODE: 'MODE',
+  TIMEOUT: 'TIMEOUT',
+  CONNECTIVITY: 'CONNECTIVITY',
+  ROUTE64: 'ROUTE64',
+  LEADER_DATA: 'LEADER_DATA',
+  NETWORK_DATA: 'NETWORK_DATA',
+  IPV6_ADDRESS_LIST: 'IPV6_ADDRESS_LIST',
+  MAC_COUNTERS: 'MAC_COUNTERS',
+  BATTERY_LEVEL: 'BATTERY_LEVEL',
+  SUPPLY_VOLTAGE: 'SUPPLY_VOLTAGE',
+  CHILD_TABLE: 'CHILD_TABLE',
+  CHANNEL_PAGES: 'CHANNEL_PAGES',
+  TYPE_LIST: 'TYPE_LIST',
+  MAX_CHILD_TIMEOUT: 'MAX_CHILD_TIMEOUT'
+});
+
+const DIAGNOSTIC_DEFAULT_TIMEOUT = 10000; // 10 seconds
+
 /**
  * Mixin class for a Mesh device.
  */
@@ -195,5 +217,22 @@ export const MeshDevice = base => class extends base {
     } finally {
       await this.leaveListeningMode(); // Restore the device state
     }
+  }
+
+  /**
+   * Collect network diagnostic information
+   *
+   * @param {Object} opts Request options
+   * @return {Promise}
+   */
+  async getNetworkDiagnostics(opts = {
+      timeout: DIAGNOSTIC_DEFAULT_TIMEOUT,
+      queryChildren: false,
+      diagnosticTypes: ['RLOC']
+  }) {
+    return this.sendRequest(RequestType.MESH_GET_NETWORK_DIAGNOSTICS, {
+      flags: opts.queryChildren ? proto.mesh.GetNetworkDiagnosticsRequest.Flags['QUERY_CHILDREN'] : 0,
+      diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf)
+    });
   }
 }

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -234,8 +234,18 @@ export const MeshDevice = base => class extends base {
     if (opts.queryChildren && !opts.diagnosticTypes.includes('CHILD_TABLE')) {
       opts.diagnosticTypes.push('CHILD_TABLE');
     }
-    return this.sendProtobufRequest(RequestType.GET_NETWORK_DIAGNOSTICS, {
-      flags: opts.queryChildren ? proto.mesh.GetNetworkDiagnosticsRequest.Flags['QUERY_CHILDREN'] : 0,
+
+    let flags = 0;
+    if (opts.queryChildren) {
+      flags |= proto.mesh.GetNetworkDiagnosticsRequest.Flags['QUERY_CHILDREN'];
+    }
+
+    if (opts.resolveDeviceId) {
+      flags |= proto.mesh.GetNetworkDiagnosticsRequest.Flags['RESOLVE_DEVICE_ID'];
+    }
+
+    return this.sendRequest(RequestType.GET_NETWORK_DIAGNOSTICS, {
+      flags: flags,
       diagnosticTypes: opts.diagnosticTypes.map(DiagnosticType.toProtobuf),
       timeout: timeout
     });

--- a/src/request.js
+++ b/src/request.js
@@ -2,6 +2,11 @@ import proto from './protocol';
 
 // Mapping of request types to Protobuf messages
 export const Request = {
+  GET_SERIAL_NUMBER: {
+    id: 21,
+    request: proto.GetSerialNumberRequest,
+    reply: proto.GetSerialNumberReply
+  },
   RESET: {
     id: 40
   },
@@ -241,5 +246,10 @@ export const Request = {
     id: 1011,
     request: proto.mesh.ScanNetworksRequest,
     reply: proto.mesh.ScanNetworksReply
+  },
+  MESH_GET_NETWORK_DIAGNOSTICS: {
+    id: 1012,
+    request: proto.mesh.GetNetworkDiagnosticsRequest,
+    reply: proto.mesh.GetNetworkDiagnosticsReply
   }
 };

--- a/test/mesh-network-diagnostics.js
+++ b/test/mesh-network-diagnostics.js
@@ -1,0 +1,61 @@
+import { getDevices } from '../src/particle-usb';
+import { RequestError } from '../src/error';
+
+import { expect } from './support';
+
+// Note: This test requires physical device to be connected to the host via USB and is skipped by default
+describe.skip('mesh-network-diagnostics', function() {
+  // Mesh device operations may take a while
+  this.timeout(60000);
+  this.slow(45000);
+
+  let dev = null;
+
+  before(async () => {
+    let devs = await getDevices();
+    devs = devs.filter(dev => dev.isMeshDevice);
+    dev = devs[0];
+    await dev.open();
+  });
+
+  after(async () => {
+    await dev.close();
+  });
+
+  describe('MeshDevice', () => {
+    describe('getNetworkDiagnostics()', () => {
+      it('gets diagnostic info about the current mesh network from one of the nodes', async () => {
+        const diag = await dev.getNetworkDiagnostics({
+          queryChildren: true,
+          resolveDeviceId: true,
+          diagnosticTypes: [
+              'MAC_EXTENDED_ADDRESS',
+              'RLOC',
+              'MAC_ADDRESS',
+              'MODE',
+              'TIMEOUT',
+              'CONNECTIVITY',
+              'ROUTE64',
+              'LEADER_DATA',
+              'NETWORK_DATA',
+              'IPV6_ADDRESS_LIST',
+              'MAC_COUNTERS',
+              'BATTERY_LEVEL',
+              'SUPPLY_VOLTAGE',
+              'CHILD_TABLE',
+              'CHANNEL_PAGES',
+              'MAX_CHILD_TIMEOUT'
+          ]
+        });
+        expect(diag).to.be.an('object');
+        expect(diag).to.have.key('nodes');
+        expect(diag.nodes).to.be.an('array');
+        expect(diag.nodes).to.have.lengthOf.above(0);
+        diag.nodes.forEach(node => {
+            expect(node).to.have.property('rloc');
+        });
+        expect(diag.nodes).to.containSubset([{ deviceId: Buffer.from(dev.id, 'hex') }]);
+      });
+    })
+  });
+});

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -4,6 +4,7 @@ import { config } from '../../src/config';
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import chaiSubset from 'chai-subset';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import 'mocha-sinon';
@@ -12,6 +13,7 @@ import * as util from 'util';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
+chai.use(chaiSubset);
 
 class Logger {
   trace(...args) {


### PR DESCRIPTION
Implements `getNetworkDiagnostics()` for Mesh devices.

### Example app
```js
import * as usb from 'particle-usb';
import * as util from 'util';

const DEVICE_ID = '123456';

async function main() {
  const device = await usb.openDeviceById(DEVICE_ID);

  return device.getNetworkDiagnostics({
    queryChildren: true,
    // Not supported in https://github.com/particle-iot/device-os/pull/1657 yet
    resolveDeviceId: true,
    diagnosticTypes: [
      'MAC_EXTENDED_ADDRESS',
      'RLOC',
      'MAC_ADDRESS',
      'MODE',
      'TIMEOUT',
      'CONNECTIVITY',
      'ROUTE64',
      'LEADER_DATA',
      'NETWORK_DATA',
      'IPV6_ADDRESS_LIST',
      'MAC_COUNTERS',
      'BATTERY_LEVEL',
      'SUPPLY_VOLTAGE',
      'CHILD_TABLE',
      'CHANNEL_PAGES',
      'MAX_CHILD_TIMEOUT'
    ]
  });
}

main().then(
  text => {
    console.log(util.inspect(text, false, null, true));
  },
  err => {
    console.log(err);
  }
);
```

### References
- https://github.com/particle-iot/firmware-protobuf/pull/3
- https://github.com/particle-iot/device-os/pull/1657
- [CH26550]