### PR TITLE
Improve error reporting

### DIFF
--- a/src/device-base.js
+++ b/src/device-base.js
@@ -677,6 +677,9 @@ export async function getDevices({ types = [], includeDfu = true } = {}) {
       }
     }
   });
+  if (filters.length == 0) {
+    return [];
+  }
   const devs = await getUsbDevices(filters);
   return devs.map(dev => {
     const info = deviceInfoForUsbIds(dev.vendorId, dev.productId);

--- a/src/device-type.js
+++ b/src/device-type.js
@@ -6,10 +6,12 @@ export const DeviceType = {
   PHOTON: 'Photon',
   P1: 'P1',
   ELECTRON: 'Electron',
-  DUO: 'Duo',
-  XENON: 'Xenon',
   ARGON: 'Argon',
-  BORON: 'Boron'
+  BORON: 'Boron',
+  XENON: 'Xenon',
+  ARGON_SOM: 'Argon-SoM',
+  BORON_SOM: 'Boron-SoM',
+  XENON_SOM: 'Xenon-SoM'
 };
 
 // Descriptions of all devices supported by the library
@@ -19,7 +21,7 @@ export const DEVICES = [
     platformId: 0,
     usbIds: {
       vendorId: 0x1d50,
-      productId: 0x607d,
+      productId: 0x607d
     },
     dfuUsbIds: {
       vendorId: 0x1d50,
@@ -31,7 +33,7 @@ export const DEVICES = [
     platformId: 6,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc006,
+      productId: 0xc006
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -43,7 +45,7 @@ export const DEVICES = [
     platformId: 8,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc008,
+      productId: 0xc008
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -55,7 +57,7 @@ export const DEVICES = [
     platformId: 10,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc00a,
+      productId: 0xc00a
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -67,7 +69,7 @@ export const DEVICES = [
     platformId: 12,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc00c,
+      productId: 0xc00c
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -79,7 +81,7 @@ export const DEVICES = [
     platformId: 13,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc00d,
+      productId: 0xc00d
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -91,7 +93,7 @@ export const DEVICES = [
     platformId: 14,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc00e,
+      productId: 0xc00e
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
@@ -99,15 +101,39 @@ export const DEVICES = [
     }
   },
   {
-    type: DeviceType.DUO,
-    platformId: 88,
+    type: DeviceType.ARGON_SOM,
+    platformId: 22,
     usbIds: {
       vendorId: 0x2b04,
-      productId: 0xc058,
+      productId: 0xc016
     },
     dfuUsbIds: {
       vendorId: 0x2b04,
-      productId: 0xd058
+      productId: 0xd016
+    }
+  },
+  {
+    type: DeviceType.BORON_SOM,
+    platformId: 23,
+    usbIds: {
+      vendorId: 0x2b04,
+      productId: 0xc017
+    },
+    dfuUsbIds: {
+      vendorId: 0x2b04,
+      productId: 0xd017
+    }
+  },
+  {
+    type: DeviceType.XENON_SOM,
+    platformId: 24,
+    usbIds: {
+      vendorId: 0x2b04,
+      productId: 0xc018
+    },
+    dfuUsbIds: {
+      vendorId: 0x2b04,
+      productId: 0xd018
     }
   }
 ];

--- a/src/error.js
+++ b/src/error.js
@@ -11,7 +11,7 @@ export class DeviceError extends VError {
 }
 
 /**
- * Error reported when a requested entity cannot be found.
+ * An error reported when a requested resource cannot be found.
  */
 export class NotFoundError extends DeviceError {
   constructor(...args) {
@@ -21,7 +21,17 @@ export class NotFoundError extends DeviceError {
 }
 
 /**
- * Error reported when an object is not in an appropriate state to perform an operation.
+ * An error reported when a requested operation is not permitted.
+ */
+export class NotAllowedError extends DeviceError {
+  constructor(...args) {
+    super(...args);
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * An error reported when an object is not in an appropriate state to perform an operation.
  */
 export class StateError extends DeviceError {
   constructor(...args) {
@@ -41,7 +51,7 @@ export class TimeoutError extends DeviceError {
 }
 
 /**
- * Error reported when an endpoint device has no enough memory to perform an operation.
+ * An error reported when a device has no enough memory to perform an operation.
  */
 export class MemoryError extends DeviceError {
   constructor(...args) {

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -30,16 +30,22 @@ export class P1 extends CloudDevice(WifiDevice(NetworkDevice(Device))) {
 export class Electron extends CloudDevice(CellularDevice(NetworkDevice(Device))) {
 }
 
-export class Duo extends CloudDevice(WifiDevice(NetworkDevice(Device))) {
+export class Argon extends CloudDevice(WifiDevice(MeshDevice(NetworkDevice(Device)))) {
+}
+
+export class Boron extends CloudDevice(CellularDevice(MeshDevice(NetworkDevice(Device)))) {
 }
 
 export class Xenon extends CloudDevice(MeshDevice(NetworkDevice(Device))) {
 }
 
-export class Argon extends CloudDevice(WifiDevice(MeshDevice(NetworkDevice(Device)))) {
+export class ArgonSom extends CloudDevice(WifiDevice(MeshDevice(NetworkDevice(Device)))) {
 }
 
-export class Boron extends CloudDevice(CellularDevice(MeshDevice(NetworkDevice(Device)))) {
+export class BoronSom extends CloudDevice(CellularDevice(MeshDevice(NetworkDevice(Device)))) {
+}
+
+export class XenonSom extends CloudDevice(MeshDevice(NetworkDevice(Device))) {
 }
 
 const DEVICE_PROTOTYPES = {
@@ -47,10 +53,12 @@ const DEVICE_PROTOTYPES = {
   [DeviceType.PHOTON]: Photon.prototype,
   [DeviceType.P1]: P1.prototype,
   [DeviceType.ELECTRON]: Electron.prototype,
-  [DeviceType.DUO]: Duo.prototype,
-  [DeviceType.XENON]: Xenon.prototype,
   [DeviceType.ARGON]: Argon.prototype,
   [DeviceType.BORON]: Boron.prototype,
+  [DeviceType.XENON]: Xenon.prototype,
+  [DeviceType.ARGON_SOM]: ArgonSom.prototype,
+  [DeviceType.BORON_SOM]: BoronSom.prototype,
+  [DeviceType.XENON_SOM]: XenonSom.prototype
 };
 
 function setDevicePrototype(dev) {

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -14,8 +14,8 @@ export { NetworkStatus } from './network-device';
 export { WifiAntenna, WifiSecurity, WifiCipher, EapMethod } from './wifi-device';
 export { ServerProtocol } from './cloud-device';
 export { Result } from './result';
-export { DeviceError, NotFoundError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError, InternalError,
-    RequestError } from './error';
+export { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError,
+    InternalError, RequestError } from './error';
 export { config } from './config';
 
 export class Core extends DeviceBase {

--- a/test/integration/mesh-device.js
+++ b/test/integration/mesh-device.js
@@ -33,11 +33,11 @@ describe('mesh-device', function() {
   });
 
   after(async () => {
-    if (dev1) {
+    if (dev1 && dev1.isOpen) {
       await dev1.leaveMeshNetwork();
       await dev1.close();
     }
-    if (dev2) {
+    if (dev2 && dev2.isOpen) {
       await dev2.leaveMeshNetwork();
       await dev2.close();
     }

--- a/test/support/fake-usb.js
+++ b/test/support/fake-usb.js
@@ -16,8 +16,12 @@ const USB_DEVICES = [
   { type: 'Boron', platformId: 13, vendorId: 0x2b04, productId: 0xd00d, dfu: true },
   { type: 'Xenon', platformId: 14, vendorId: 0x2b04, productId: 0xc00e, dfu: false },
   { type: 'Xenon', platformId: 14, vendorId: 0x2b04, productId: 0xd00e, dfu: true },
-  { type: 'Duo', platformId: 88, vendorId: 0x2b04, productId: 0xc058, dfu: false },
-  { type: 'Duo', platformId: 88, vendorId: 0x2b04, productId: 0xd058, dfu: true }
+  { type: 'Argon-SoM', platformId: 22, vendorId: 0x2b04, productId: 0xc016, dfu: false },
+  { type: 'Argon-SoM', platformId: 22, vendorId: 0x2b04, productId: 0xd016, dfu: true },
+  { type: 'Boron-SoM', platformId: 23, vendorId: 0x2b04, productId: 0xc017, dfu: false },
+  { type: 'Boron-SoM', platformId: 23, vendorId: 0x2b04, productId: 0xd017, dfu: true },
+  { type: 'Xenon-SoM', platformId: 24, vendorId: 0x2b04, productId: 0xc018, dfu: false },
+  { type: 'Xenon-SoM', platformId: 24, vendorId: 0x2b04, productId: 0xd018, dfu: true }
 ];
 
 // Low-level vendor requests
@@ -406,8 +410,13 @@ export function addElectron(options) {
   return addDevice(opts);
 }
 
-export function addDuo(options) {
-  const opts = Object.assign({}, options, { type: 'Duo' });
+export function addArgon(options) {
+  const opts = Object.assign({}, options, { type: 'Argon' });
+  return addDevice(opts);
+}
+
+export function addBoron(options) {
+  const opts = Object.assign({}, options, { type: 'Boron' });
   return addDevice(opts);
 }
 
@@ -416,13 +425,18 @@ export function addXenon(options) {
   return addDevice(opts);
 }
 
-export function addArgon(options) {
-  const opts = Object.assign({}, options, { type: 'Argon' });
+export function addArgonSom(options) {
+  const opts = Object.assign({}, options, { type: 'Argon-SoM' });
   return addDevice(opts);
 }
 
-export function addBoron(options) {
-  const opts = Object.assign({}, options, { type: 'Boron' });
+export function addBoronSom(options) {
+  const opts = Object.assign({}, options, { type: 'Boron-SoM' });
+  return addDevice(opts);
+}
+
+export function addXenonSom(options) {
+  const opts = Object.assign({}, options, { type: 'Xenon-SoM' });
   return addDevice(opts);
 }
 


### PR DESCRIPTION
This PR updates `getDevices()` and `openDeviceById()` to throw a `NotAllowedError` exception if the user has no permission to access a device supported by the library. This is important for the CLI which should be able to automatically update udev rules if necessary.

#### Steps to test

Connect a Boron and a Xenon to your computer and run:
```bash
RUN_INTEGRATION_TESTS=1 npm test
```