### PR TITLE
 Filter out non-printable ASCII characters from the device ID string 

### DIFF
--- a/src/device-base.js
+++ b/src/device-base.js
@@ -108,8 +108,8 @@ export class DeviceBase extends EventEmitter {
     this._log.trace('Opening device');
     this._state = DeviceState.OPENING;
     return this._dev.open().then(() => {
-      // Pre-0.7.0 firmwares report the device ID in upper case
-      this._id = this._dev.serialNumber.toLowerCase();
+      // Normalize the device ID string
+      this._id = this._dev.serialNumber.replace(/[^\x20-\x7e]/g, '').toLowerCase();
       this._log.trace(`Device ID: ${this._id}`);
       // Get firmware version
       return this._getFirmwareVersion().then(ver => {

--- a/test/device-base.js
+++ b/test/device-base.js
@@ -222,6 +222,18 @@ describe('device-base', () => {
         expect(dev.firmwareVersion).to.equal('1.0.0');
       });
 
+      it('filters out non-printable ASCII characters from the device ID string', async () => {
+        usbDev.options.serialNumber = '222222222222222222222222\x00'
+        await dev.open();
+        expect(dev.id).to.equal('222222222222222222222222');
+      });
+
+      it('converts the device ID string to lower case', async () => {
+        usbDev.options.serialNumber = 'AAAAAAAAAAAAAAAAAAAAAAAA'
+        await dev.open();
+        expect(dev.id).to.equal('aaaaaaaaaaaaaaaaaaaaaaaa');
+      });
+
       it('does not require the USB device to support the firmware version request', async () => {
         usbDev.options.firmwareVersion = null;
         await dev.open();


### PR DESCRIPTION
The Core incorrectly returns a null-terminated serial number string, which causes the CLI's `usb list` command to fail.