### PR TITLE
Fix Device.updateFirmware()

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -157,8 +157,8 @@ export const Request = {
   },
   FIRMWARE_UPDATE_DATA: {
     id: 253,
-    request: proto.SaveFirmwareDataRequest,
-    reply: proto.SaveFirmwareDataReply
+    request: proto.FirmwareUpdateDataRequest,
+    reply: proto.FirmwareUpdateDataReply
   },
   DESCRIBE_STORAGE: {
     id: 260,


### PR DESCRIPTION
It turns out `Device.updateFirmware()` no longer works due to some renamings made in the protocol files.