### PR TITLE
Do not ignore default-initialized message fields

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -535,10 +535,11 @@ export class Device extends DeviceBase {
 			}
 			if (req.reply) {
 				if (rep.data) {
-					r = Object.assign({}, r, req.reply.decode(rep.data));
+					// Parse the response message
+					r = Object.assign(req.reply.decode(rep.data), r);
 				} else {
-					// Return a message with default-initialized properties
-					r = Object.assign({}, r, req.reply.create());
+					// Create a message with default-initialized properties
+					r = Object.assign(req.reply.create(), r);
 				}
 			}
 			return r;


### PR DESCRIPTION
This PR fixes an issue where `Device.sendRequest()` doesn't return message fields which are not own properties of the decoded response message object. This is typically the case when some fields of a response message are set to zero.
