### PR TITLE
Add methods to force the device to reset or disconnect from the cloud

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 // Global configuration
 export let globalOptions = {
 	// Request timeout
-	requestTimeout: 30000,
+	requestTimeout: 60000,
 	// Logger instance
 	log: {
 		trace: () => {},

--- a/src/device.js
+++ b/src/device.js
@@ -106,12 +106,12 @@ export class Device extends DeviceBase {
 	 *
 	 * @return {Promise}
 	 */
-	async reset({ force = false } = {}) {
+	async reset({ force = false, timeout = globalOptions.requestTimeout } = {}) {
 		if (this.isInDfuMode) {
 			return super.reset();
 		}
 		if (!force) {
-			return this.sendRequest(Request.RESET);
+			return this.sendRequest(Request.RESET, null /* msg */, { timeout });
 		}
 		const setup = {
 			bmRequestType: usbProto.BmRequestType.HOST_TO_DEVICE,
@@ -208,7 +208,7 @@ export class Device extends DeviceBase {
 	/**
 	 * Connect to the cloud.
 	 */
-	async connectToCloud({ dontWait = false, timeout = undefined } = {}) {
+	async connectToCloud({ dontWait = false, timeout = globalOptions.requestTimeout } = {}) {
 		await this.timeout(timeout, async (s) => {
 			await s.sendRequest(Request.CLOUD_CONNECT);
 			if (!dontWait) {
@@ -226,7 +226,7 @@ export class Device extends DeviceBase {
 	/**
 	 * Disconnect from the cloud.
 	 */
-	async disconnectFromCloud({ dontWait = false, force = false, timeout = undefined } = {}) {
+	async disconnectFromCloud({ dontWait = false, force = false, timeout = globalOptions.requestTimeout } = {}) {
 		if (force) {
 			const setup = {
 				bmRequestType: usbProto.BmRequestType.HOST_TO_DEVICE,

--- a/src/device.js
+++ b/src/device.js
@@ -550,6 +550,9 @@ export class Device extends DeviceBase {
 	async timeout(ms, fn) {
 		if (typeof ms === 'function') {
 			fn = ms;
+			ms = undefined;
+		}
+		if (!ms) {
 			ms = globalOptions.requestTimeout; // Default timeout
 		}
 		const s = new RequestSender(this, ms);

--- a/src/request.js
+++ b/src/request.js
@@ -44,11 +44,6 @@ export const Request = {
 	DIAGNOSTIC_INFO: {
 		id: 100
 	},
-	GET_CONNECTION_STATUS: {
-		id: 300,
-		request: proto.cloud.GetConnectionStatusRequest,
-		reply: proto.cloud.GetConnectionStatusReply
-	},
 	WIFI_SET_ANTENNA: {
 		id: 110,
 		request: proto.WiFiSetAntennaRequest,
@@ -189,6 +184,22 @@ export const Request = {
 		id: 264,
 		request: proto.GetSectionDataSizeRequest,
 		reply: proto.GetSectionDataSizeReply
+	},
+	// Cloud connectivity
+	CLOUD_STATUS: {
+		id: 300,
+		request: proto.cloud.GetConnectionStatusRequest,
+		reply: proto.cloud.GetConnectionStatusReply
+	},
+	CLOUD_CONNECT: {
+		id: 301,
+		request: proto.cloud.ConnectRequest,
+		reply: proto.cloud.ConnectReply
+	},
+	CLOUD_DISCONNECT: {
+		id: 302,
+		request: proto.cloud.DisconnectRequest,
+		reply: proto.cloud.DisconnectReply
 	},
 	// Cellular-specific requests
 	CELLULAR_GET_ICCID: {

--- a/src/usb-device-node.js
+++ b/src/usb-device-node.js
@@ -89,6 +89,9 @@ export class UsbDevice {
 
 	transferOut(setup, data) {
 		return new Promise((resolve, reject) => {
+			if (!data) {
+				data = Buffer.alloc(0);
+			}
 			this._dev.controlTransfer(setup.bmRequestType, setup.bRequest, setup.wValue, setup.wIndex, data, err => {
 				if (err) {
 					return reject(wrapUsbError(err, 'OUT control transfer failed'));
@@ -165,6 +168,10 @@ export class UsbDevice {
 
 	get isOpen() {
 		return this._dev.particle.isOpen;
+	}
+
+	get internalObject() {
+		return this._dev;
 	}
 }
 

--- a/src/usb-device-webusb.js
+++ b/src/usb-device-webusb.js
@@ -85,7 +85,7 @@ export class UsbDevice {
 				request: setup.bRequest,
 				value: setup.wValue,
 				index: setup.wIndex
-			}, data);
+			}, data); // data is optional
 		} catch (err) {
 			throw new UsbError(err, 'OUT control transfer failed');
 		}
@@ -129,6 +129,10 @@ export class UsbDevice {
 
 	get isOpen() {
 		return this._dev.opened;
+	}
+
+	get internalObject() {
+		return this._dev;
 	}
 }
 


### PR DESCRIPTION
This PR introduces the following changes:

- Add an option to `Device.reset()` to reset the device immediately using a low-level vendor-specific request.
- Add methods for connecting/disconnecting the device to/from the cloud.
- Increase the default request timeout to 60 seconds.
- Expose the internal USB device object via an API property.

Steps to test: https://github.com/particle-iot/device-os/pull/2142
