### PR TITLE
Add timeout option to high-level API methods

### DIFF
--- a/src/cellular-device.js
+++ b/src/cellular-device.js
@@ -1,4 +1,5 @@
 import { Request } from './request';
+import { globalOptions } from './config';
 
 /**
  * Mixin class for a cellular network device.
@@ -9,8 +10,8 @@ export const CellularDevice = base => class extends base {
 	 *
 	 * @return {Promise<String>}
 	 */
-	async getIccid() {
-		const r = await this.sendRequest(Request.CELLULAR_GET_ICCID);
+	async getIccid({ timeout = globalOptions.requestTimeout } = {}) {
+		const r = await this.sendRequest(Request.CELLULAR_GET_ICCID, null /* msg */, { timeout });
 		return r.iccid;
 	}
 

--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -5,6 +5,16 @@ import { globalOptions } from './config';
 import proto from './protocol';
 
 /**
+ * Cloud connection status.
+ */
+export const CloudConnectionStatus = fromProtobufEnum(proto.cloud.ConnectionStatus, {
+	DISCONNECTED: 'DISCONNECTED',
+	CONNECTING: 'CONNECTING',
+	CONNECTED: 'CONNECTED',
+	DISCONNECTING: 'DISCONNECTING'
+});
+
+/**
  * Server protocol types.
  */
 export const ServerProtocol = fromProtobufEnum(proto.ServerProtocolType, {
@@ -16,6 +26,64 @@ export const ServerProtocol = fromProtobufEnum(proto.ServerProtocolType, {
  * Mixin class for a cloud-enabled device.
  */
 export const CloudDevice = base => class extends base {
+	/**
+	 * Connect to the cloud.
+	 */
+	async connectToCloud({ dontWait = false, timeout = globalOptions.requestTimeout } = {}) {
+		await this.timeout(timeout, async (s) => {
+			await s.sendRequest(Request.CLOUD_CONNECT);
+			if (!dontWait) {
+				for (;;) {
+					const r = await s.sendRequest(Request.CLOUD_STATUS);
+					if (r.status === proto.cloud.ConnectionStatus.CONNECTED) {
+						break;
+					}
+					await s.delay(500);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Disconnect from the cloud.
+	 */
+	async disconnectFromCloud({ dontWait = false, force = false, timeout = globalOptions.requestTimeout } = {}) {
+		if (force) {
+			const setup = {
+				bmRequestType: usbProto.BmRequestType.HOST_TO_DEVICE,
+				bRequest: usbProto.PARTICLE_BREQUEST,
+				wIndex: Request.CLOUD_DISCONNECT.id,
+				wValue: 0
+			};
+			await this.usbDevice.transferOut(setup);
+			if (dontWait) {
+				return;
+			}
+		}
+		await this.timeout(timeout, async (s) => {
+			if (!force) {
+				await s.sendRequest(Request.CLOUD_DISCONNECT);
+			}
+			if (!dontWait) {
+				for (;;) {
+					const r = await s.sendRequest(Request.CLOUD_STATUS);
+					if (r.status === proto.cloud.ConnectionStatus.DISCONNECTED) {
+						break;
+					}
+					await s.delay(500);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Get the cloud connection status.
+	 */
+	async getCloudConnectionStatus({ timeout = globalOptions.requestTimeout } = {}) {
+		const r = await this.sendRequest(Request.CLOUD_STATUS, null /* msg */, { timeout });
+		return CloudConnectionStatus.fromProtobuf(r.status);
+	}
+
 	/**
 	 * Set the claim code.
 	 *

--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -1,5 +1,6 @@
 import { Request } from './request';
 import { fromProtobufEnum } from './protobuf-util';
+import { globalOptions } from './config';
 
 import proto from './protocol';
 
@@ -21,10 +22,8 @@ export const CloudDevice = base => class extends base {
 	 * @param {String} code Claim code.
 	 * @return {Promise}
 	 */
-	setClaimCode(code) {
-		return this.sendRequest(Request.SET_CLAIM_CODE, {
-			code: code
-		});
+	setClaimCode(code, { timeout = globalOptions.requestTimeout } = {}) {
+		return this.sendRequest(Request.SET_CLAIM_CODE, { code }, { timeout });
 	}
 
 	/**
@@ -32,9 +31,11 @@ export const CloudDevice = base => class extends base {
 	 *
 	 * @return {Promise<Boolean>}
 	 */
-	isClaimed() {
-		return this.sendRequest(Request.IS_CLAIMED).then(rep => rep.claimed);
+	isClaimed({ timeout = globalOptions.requestTimeout } = {}) {
+		return this.sendRequest(Request.IS_CLAIMED, null /* msg */, { timeout }).then(rep => rep.claimed);
 	}
+
+	// TODO: The methods below are not supported in recent versions of Device OS. Remove them in particle-usb@2.0.0
 
 	/**
 	 * Set the device private key.

--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -1,5 +1,6 @@
 import { Request } from './request';
 import { fromProtobufEnum } from './protobuf-util';
+import * as usbProto from './usb-protocol';
 import { globalOptions } from './config';
 
 import proto from './protocol';

--- a/src/device.js
+++ b/src/device.js
@@ -88,8 +88,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @return {Promise}
 	 */
-	getSerialNumber({ timeout = globalOptions.requestTimeout } = {}) {
-		return this.sendRequest(Request.GET_SERIAL_NUMBER, null /* msg */, { timeout });
+	async getSerialNumber({ timeout = globalOptions.requestTimeout } = {}) {
+		const r = await this.sendRequest(Request.GET_SERIAL_NUMBER, null /* msg */, { timeout });
+		return r.serial;
 	}
 
 	/**

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -121,6 +121,7 @@ function transformNetworkDiagnosticInfo(info) {
 /**
  * Mixin class for a Mesh device.
  */
+// TODO: Mesh support is deprecated. Remove this class in particle-usb@2.0.0
 export const MeshDevice = base => class extends base {
 	/**
 	 * Authenticate the host on the device.

--- a/src/network-device.js
+++ b/src/network-device.js
@@ -16,6 +16,8 @@ export const NetworkStatus = fromProtobufEnum(proto.NetworkState, {
 /**
  * Mixin class for a network device.
  */
+// TODO: Recent versions of Device OS use a different network configuration interface and the
+// methods of this class no longer work
 export const NetworkDevice = base => class extends base {
 	/**
 	 * Get network status.

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -12,7 +12,7 @@ export { PollingPolicy } from './device-base';
 export { FirmwareModule } from './device';
 export { NetworkStatus } from './network-device';
 export { WifiAntenna, WifiSecurity, WifiCipher, EapMethod } from './wifi-device';
-export { ServerProtocol } from './cloud-device';
+export { CloudConnectionStatus, ServerProtocol } from './cloud-device';
 export { Result } from './result';
 export { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError,
 	InternalError, RequestError } from './error';

--- a/src/wifi-device.js
+++ b/src/wifi-device.js
@@ -76,7 +76,10 @@ const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPoi
 /**
  * Mixin class for a WiFi device.
  */
+// TODO: Recent versions of Device OS use a different network configuration interface and the
+// methods of this class no longer work
 export const WifiDevice = base => class extends base {
+	// TODO: The methods below are not supported in recent versions of Device OS. Remove them in particle-usb@2.0.0
 	/**
 	 * Set the WiFi antenna to use.
 	 *

--- a/src/wifi-device.js
+++ b/src/wifi-device.js
@@ -79,7 +79,6 @@ const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPoi
 // TODO: Recent versions of Device OS use a different network configuration interface and the
 // methods of this class no longer work
 export const WifiDevice = base => class extends base {
-	// TODO: The methods below are not supported in recent versions of Device OS. Remove them in particle-usb@2.0.0
 	/**
 	 * Set the WiFi antenna to use.
 	 *


### PR DESCRIPTION
This PR adds a timeout argument to all supported methods of the `Device` and `CloudDevice` classes. I tested all affected methods manually, since we don't have unit tests for the high-level API.