### PR TITLE
Improve reference docs

### DIFF
--- a/src/cellular-device.js
+++ b/src/cellular-device.js
@@ -2,12 +2,23 @@ import { Request } from './request';
 import { globalOptions } from './config';
 
 /**
- * Mixin class for a cellular network device.
+ * Cellular device.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
  */
 export const CellularDevice = base => class extends base {
 	/**
 	 * Get ICCID of the active SIM card.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.1.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise<String>}
 	 */
 	async getIccid({ timeout = globalOptions.requestTimeout } = {}) {

--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -7,28 +7,53 @@ import proto from './protocol';
 
 /**
  * Cloud connection status.
+ *
+ * @enum {String}
  */
 export const CloudConnectionStatus = fromProtobufEnum(proto.cloud.ConnectionStatus, {
+	/** Disconnected. */
 	DISCONNECTED: 'DISCONNECTED',
+	/** Connecting. */
 	CONNECTING: 'CONNECTING',
+	/** Connected. */
 	CONNECTED: 'CONNECTED',
+	/** Disconnecting. */
 	DISCONNECTING: 'DISCONNECTING'
 });
 
 /**
  * Server protocol types.
+ *
+ * @enum {String}
  */
 export const ServerProtocol = fromProtobufEnum(proto.ServerProtocolType, {
+	/** TCP. */
 	TCP: 'TCP_PROTOCOL',
+	/** UDP. */
 	UDP: 'UDP_PROTOCOL'
 });
 
 /**
- * Mixin class for a cloud-enabled device.
+ * Cloud-enabled device.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
  */
 export const CloudDevice = base => class extends base {
 	/**
 	 * Connect to the cloud.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.1.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Boolean} [options.dontWait] Do wait for the device to actually connect to the cloud and
+	 *        return immediately.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @return {Promise}
 	 */
 	async connectToCloud({ dontWait = false, timeout = globalOptions.requestTimeout } = {}) {
 		await this.timeout(timeout, async (s) => {
@@ -47,6 +72,20 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Disconnect from the cloud.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.1.0)
+	 *
+	 * The `force` option is supported since Device OS 2.0.0.
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Boolean} [options.dontWait] Do wait for the device to actually disconnect from the cloud
+	 *        and return immediately.
+	 * @param {Boolean} [options.force] Disconnect immediately, even if the device is busy performing
+	 *        some operation with the cloud.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @return {Promise}
 	 */
 	async disconnectFromCloud({ dontWait = false, force = false, timeout = globalOptions.requestTimeout } = {}) {
 		if (force) {
@@ -79,6 +118,14 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Get the cloud connection status.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.1.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @return {Promise<CloudConnectionStatus>}
 	 */
 	async getCloudConnectionStatus({ timeout = globalOptions.requestTimeout } = {}) {
 		const r = await this.sendRequest(Request.CLOUD_STATUS, null /* msg */, { timeout });
@@ -88,7 +135,13 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Set the claim code.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
 	 * @param {String} code Claim code.
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	setClaimCode(code, { timeout = globalOptions.requestTimeout } = {}) {
@@ -98,16 +151,23 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Check if the device is claimed.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise<Boolean>}
 	 */
 	isClaimed({ timeout = globalOptions.requestTimeout } = {}) {
 		return this.sendRequest(Request.IS_CLAIMED, null /* msg */, { timeout }).then(rep => rep.claimed);
 	}
 
-	// TODO: The methods below are not supported in recent versions of Device OS. Remove them in particle-usb@2.0.0
-
 	/**
 	 * Set the device private key.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
@@ -124,6 +184,9 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Get the device private key.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -137,6 +200,9 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Set the device public key.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
@@ -153,6 +219,9 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Get the device public key.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -166,6 +235,9 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Set the server public key.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
@@ -182,6 +254,9 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Get the server public key.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -195,6 +270,9 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Set the server address.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {String} data Host address.
 	 * @param {Number} port Port number.
@@ -214,6 +292,9 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Get the server address.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Object>}
 	 */
@@ -228,6 +309,9 @@ export const CloudDevice = base => class extends base {
 	/**
 	 * Set the server protocol.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {String} protocol Server protocol.
 	 * @return {Promise}
 	 */
@@ -239,6 +323,9 @@ export const CloudDevice = base => class extends base {
 
 	/**
 	 * Get the server protocol.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @return {Promise<String>}
 	 */

--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -169,6 +169,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise}
@@ -187,6 +190,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -203,6 +209,9 @@ export const CloudDevice = base => class extends base {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
@@ -222,6 +231,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -238,6 +250,9 @@ export const CloudDevice = base => class extends base {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Buffer} data Key data.
 	 * @param {String} [protocol] Server protocol.
@@ -257,6 +272,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Buffer>}
 	 */
@@ -273,6 +291,9 @@ export const CloudDevice = base => class extends base {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {String} data Host address.
 	 * @param {Number} port Port number.
@@ -295,6 +316,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} [protocol] Server protocol.
 	 * @return {Promise<Object>}
 	 */
@@ -312,6 +336,9 @@ export const CloudDevice = base => class extends base {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} protocol Server protocol.
 	 * @return {Promise}
 	 */
@@ -326,6 +353,9 @@ export const CloudDevice = base => class extends base {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<String>}
 	 */

--- a/src/config.js
+++ b/src/config.js
@@ -14,8 +14,12 @@ export let globalOptions = {
 /**
  * Set global options.
  *
- * @param {Object} options Options.
+ * @param {Object} [options] Options.
+ * @param {Number} [options.requestTimeout=60000] Default request timeout (milliseconds).
+ * @param {Object} [options.log] Logger instance. The logger is expected to have the following methods:
+ *                 `trace(String)`, `info(String)`, `warn(String)`, `error(String)`.
+ * @return {Object} Current options.
  */
 export function config(options) {
-	Object.assign(globalOptions, options);
+	return Object.assign(globalOptions, options);
 }

--- a/src/device-type.js
+++ b/src/device-type.js
@@ -1,18 +1,32 @@
 /**
  * Device types.
+ *
+ * @enum {String}
  */
 export const DeviceType = {
+	/** Core. */
 	CORE: 'Core',
+	/** Photon. */
 	PHOTON: 'Photon',
+	/** P1. */
 	P1: 'P1',
+	/** Electron. */
 	ELECTRON: 'Electron',
+	/** Argon. */
 	ARGON: 'Argon',
+	/** Boron. */
 	BORON: 'Boron',
+	/** Xenon. */
 	XENON: 'Xenon',
+	/** A SoM. */
 	ARGON_SOM: 'Argon-SoM',
+	/** B SoM. */
 	BORON_SOM: 'Boron-SoM',
+	/** X SoM. */
 	XENON_SOM: 'Xenon-SoM',
+	/** B5 SoM. */
 	B5_SOM: 'B5-SoM',
+	/** Tracker. */
 	ASSET_TRACKER: 'Asset-Tracker'
 };
 

--- a/src/device.js
+++ b/src/device.js
@@ -348,6 +348,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {String} module Module type.
 	 * @param {Number} [index] Module index.
 	 * @return {Promise<Buffer>}
@@ -374,6 +377,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @return {Promise<Boolean>}
 	 */
 	hasModularFirmware() {
@@ -385,6 +391,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Buffer} data Firmware data.
 	 * @return {Promise}
@@ -403,6 +412,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<Buffer>}
 	 */
@@ -425,6 +437,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {Number} address Address.
 	 * @param {Number} size Data size.
 	 * @return {Promise<Buffer>}
@@ -443,6 +458,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Number} address Address.
 	 * @param {Buffer} data Data.
@@ -463,6 +481,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @return {Promise<Number>}
 	 */
 	getConfigDataSize() {
@@ -479,6 +500,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Number} address Address.
 	 * @param {Number} size Data size.
@@ -499,6 +523,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {Number} address Address.
 	 * @param {Buffer} data Data.
 	 * @return {Promise}
@@ -518,6 +545,9 @@ export class Device extends DeviceBase {
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
 	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @return {Promise}
 	 */
 	clearEeprom() {
@@ -534,6 +564,9 @@ export class Device extends DeviceBase {
 	 *
 	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
 	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<Number>}
 	 */

--- a/src/device.js
+++ b/src/device.js
@@ -10,31 +10,49 @@ import proto from './protocol';
 
 /**
  * Firmware module types.
+ *
+ * @enum {String}
  */
 export const FirmwareModule = fromProtobufEnum(proto.FirmwareModuleType, {
+	/** Bootloader module. */
 	BOOTLOADER: 'BOOTLOADER',
+	/** System part module. */
 	SYSTEM_PART: 'SYSTEM_PART',
+	/** User part module. */
 	USER_PART: 'USER_PART',
+	/** Monolithic firmware module. */
 	MONO_FIRMWARE: 'MONO_FIRMWARE'
 });
 
 /**
  * Device modes.
+ *
+ * @enum {String}
  */
 export const DeviceMode = fromProtobufEnum(proto.DeviceMode, {
+	/** Device is in normal mode. */
 	NORMAL: 'NORMAL_MODE',
+	/** Device is in listening mode. */
 	LISTENING: 'LISTENING_MODE'
 });
 
 /**
  * Logging levels.
+ *
+ * @enum {String}
  */
 export const LogLevel = fromProtobufEnum(proto.logging.LogLevel, {
+	/** Enables logging of all messages. */
 	ALL: 'ALL',
+	/** Enables logging of trace messages. */
 	TRACE: 'TRACE',
+	/** Enables logging of info messages. */
 	INFO: 'INFO',
+	/** Enables logging of warning messages. */
 	WARN: 'WARN',
+	/** Enables logging of error messages. */
 	ERROR: 'ERROR',
+	/** Disables logging of any messages. */
 	NONE: 'NONE'
 });
 
@@ -80,13 +98,22 @@ class RequestSender {
 }
 
 /**
- * Basic functionality supported by all Particle devices.
+ * Basic functionality supported by most of Particle devices.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
  */
 export class Device extends DeviceBase {
 	/**
-	 * Get device serial number
+	 * Get the device's serial number.
 	 *
-	 * @return {Promise}
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.5.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @return {Promise<String>}
 	 */
 	async getSerialNumber({ timeout = globalOptions.requestTimeout } = {}) {
 		const r = await this.sendRequest(Request.GET_SERIAL_NUMBER, null /* msg */, { timeout });
@@ -96,6 +123,19 @@ export class Device extends DeviceBase {
 	/**
 	 * Perform the system reset.
 	 *
+	 * Note: The only safe operation that can be performed on the device instance after the device
+	 * resets is closing it via {@link DeviceBase#close}.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * The `force` option is supported since Device OS 2.0.0.
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Boolean} [options.force] Reset the device immediately, even if it is busy performing
+	 *        some blocking operation, such as writing to flash.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	async reset({ force = false, timeout = globalOptions.requestTimeout } = {}) {
@@ -117,6 +157,15 @@ export class Device extends DeviceBase {
 	/**
 	 * Perform the factory reset.
 	 *
+	 * Note: The only safe operation that can be performed on the device instance after the device
+	 * resets is closing it via {@link DeviceBase#close}.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	factoryReset({ timeout = globalOptions.requestTimeout } = {}) {
@@ -126,6 +175,15 @@ export class Device extends DeviceBase {
 	/**
 	 * Reset and enter the DFU mode.
 	 *
+	 * Note: The only safe operation that can be performed on the device instance after the device
+	 * resets is closing it via {@link DeviceBase#close}.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	enterDfuMode({ timeout = globalOptions.requestTimeout } = {}) {
@@ -153,6 +211,15 @@ export class Device extends DeviceBase {
 	/**
 	 * Reset and enter the safe mode.
 	 *
+	 * Note: The only safe operation that can be performed on the device instance after the device
+	 * resets is closing it via {@link DeviceBase#close}.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	enterSafeMode({ timeout = globalOptions.requestTimeout } = {}) {
@@ -162,6 +229,12 @@ export class Device extends DeviceBase {
 	/**
 	 * Enter the listening mode.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	async enterListeningMode({ timeout = globalOptions.requestTimeout } = {}) {
@@ -183,6 +256,12 @@ export class Device extends DeviceBase {
 	/**
 	 * Leave the listening mode.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	leaveListeningMode({ timeout = globalOptions.requestTimeout } = {}) {
@@ -190,7 +269,15 @@ export class Device extends DeviceBase {
 	}
 
 	/**
-	 * Get device mode.
+	 * Get the device mode.
+	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 1.1.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @return {Promise<DeviceMode>}
 	 */
 	async getDeviceMode({ timeout = globalOptions.requestTimeout } = {}) {
 		const r = await this.sendRequest(Request.GET_DEVICE_MODE, null /* msg */, { timeout });
@@ -200,6 +287,12 @@ export class Device extends DeviceBase {
 	/**
 	 * Start the Nyan LED indication.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	startNyanSignal({ timeout = globalOptions.requestTimeout } = {}) {
@@ -209,6 +302,12 @@ export class Device extends DeviceBase {
 	/**
 	 * Stop the Nyan LED indication.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
+	 * @param {Object} [options] Options.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	stopNyanSignal({ timeout = globalOptions.requestTimeout } = {}) {
@@ -218,9 +317,13 @@ export class Device extends DeviceBase {
 	/**
 	 * Perform the firmware update.
 	 *
+	 * Supported platforms:
+	 * - Gen 3 (since Device OS 0.9.0)
+	 * - Gen 2 (since Device OS 0.8.0)
+	 *
 	 * @param {Buffer} data Firmware data.
 	 * @param {Object} [options] Options.
-	 * @param {Number} [options.timeout] Timeout in milliseconds.
+	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
 	async updateFirmware(data, { timeout = DEFAULT_FIRMWARE_UPDATE_TIMEOUT } = {}) {
@@ -239,10 +342,11 @@ export class Device extends DeviceBase {
 		});
 	}
 
-	// TODO: The methods below are not supported in recent versions of Device OS. Remove them in particle-usb@2.0.0
-
 	/**
 	 * Get firmware module data.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {String} module Module type.
 	 * @param {Number} [index] Module index.
@@ -267,6 +371,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Check if the device runs a modular firmware.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @return {Promise<Boolean>}
 	 */
 	hasModularFirmware() {
@@ -275,6 +382,9 @@ export class Device extends DeviceBase {
 
 	/**
 	 * Set factory firmware.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Buffer} data Firmware data.
 	 * @return {Promise}
@@ -290,6 +400,9 @@ export class Device extends DeviceBase {
 
 	/**
 	 * Get factory firmware.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @return {Promise<Buffer>}
 	 */
@@ -309,6 +422,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Read configuration data.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {Number} address Address.
 	 * @param {Number} size Data size.
 	 * @return {Promise<Buffer>}
@@ -324,6 +440,9 @@ export class Device extends DeviceBase {
 
 	/**
 	 * Write configuration data.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Number} address Address.
 	 * @param {Buffer} data Data.
@@ -341,6 +460,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Get size of the configuration data.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @return {Promise<Number>}
 	 */
 	getConfigDataSize() {
@@ -354,6 +476,9 @@ export class Device extends DeviceBase {
 
 	/**
 	 * Read from EEPROM.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Number} address Address.
 	 * @param {Number} size Data size.
@@ -371,6 +496,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Write to EEPROM.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {Number} address Address.
 	 * @param {Buffer} data Data.
 	 * @return {Promise}
@@ -387,6 +515,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Clear EEPROM.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @return {Promise}
 	 */
 	clearEeprom() {
@@ -401,6 +532,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Get size of the EEPROM.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @return {Promise<Number>}
 	 */
 	getEepromSize() {
@@ -414,6 +548,9 @@ export class Device extends DeviceBase {
 
 	/**
 	 * Add a log handler.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
 	 *
 	 * @param {Object} options Options.
 	 * @param {String} options.id Handler ID.
@@ -484,6 +621,9 @@ export class Device extends DeviceBase {
 	/**
 	 * Remove a log handler.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
 	 * @param {Object} options Options.
 	 * @param {String} options.id Handler ID.
 	 * @return {Promise}
@@ -495,7 +635,10 @@ export class Device extends DeviceBase {
 	/**
 	 * Get the list of active log handlers.
 	 *
-	 * @return {Promise<Object>}
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * @return {Promise<Array<Object>>}
 	 */
 	async getLogHandlers() {
 		const rep = await this.sendRequest(Request.GET_LOG_HANDLERS);

--- a/src/mesh-device.js
+++ b/src/mesh-device.js
@@ -119,9 +119,16 @@ function transformNetworkDiagnosticInfo(info) {
 }
 
 /**
- * Mixin class for a Mesh device.
+ * Mesh device.
+ *
+ * @deprecated Mesh support has been removed in recent versions of Device OS. Methods provided by this
+ *             class will be removed in future versions of this library.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
  */
-// TODO: Mesh support is deprecated. Remove this class in particle-usb@2.0.0
 export const MeshDevice = base => class extends base {
 	/**
 	 * Authenticate the host on the device.

--- a/src/network-device.js
+++ b/src/network-device.js
@@ -14,10 +14,16 @@ export const NetworkStatus = fromProtobufEnum(proto.NetworkState, {
 });
 
 /**
- * Mixin class for a network device.
+ * Network device.
+ *
+ * @deprecated Methods provided by this class are not guaranteed to work with recent versions of
+ *             Device OS and will be removed in future versions of this library.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
  */
-// TODO: Recent versions of Device OS use a different network configuration interface and the
-// methods of this class no longer work
 export const NetworkDevice = base => class extends base {
 	/**
 	 * Get network status.

--- a/src/network-device.js
+++ b/src/network-device.js
@@ -16,9 +16,6 @@ export const NetworkStatus = fromProtobufEnum(proto.NetworkState, {
 /**
  * Network device.
  *
- * @deprecated Methods provided by this class are not guaranteed to work with recent versions of
- *             Device OS and will be removed in future versions of this library.
- *
  * This class is not meant to be instantiated directly. Use {@link getDevices} and
  * {@link openDeviceById} to create device instances.
  *
@@ -27,6 +24,12 @@ export const NetworkStatus = fromProtobufEnum(proto.NetworkState, {
 export const NetworkDevice = base => class extends base {
 	/**
 	 * Get network status.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<String>}
 	 */
@@ -39,6 +42,12 @@ export const NetworkDevice = base => class extends base {
 	/**
 	 * Get network configuration.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @return {Promise<Object>}
 	 */
 	getNetworkConfig() {
@@ -49,6 +58,12 @@ export const NetworkDevice = base => class extends base {
 
 	/**
 	 * Set network configuration.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {Object} config Network configuration.
 	 * @return {Promise}

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -77,10 +77,26 @@ function setDevicePrototype(dev) {
 	return Object.setPrototypeOf(dev, proto);
 }
 
+/**
+ * Enumerate Particle USB devices attached to the host.
+ *
+ * @param {Object} options Options.
+ * @param {Array<String>} [options.types] Device types (see {@link DeviceType}). By default, this
+ *        function enumerates devices of all platforms supported by the library.
+ * @param {Boolean} [options.includeDfu=true] Whether to include devices in DFU mode.
+ * @return {Promise<Array<Device>>}
+ */
 export function getDevices(options) {
 	return getUsbDevices(options).then(devs => devs.map(dev => setDevicePrototype(dev)));
 }
 
+/**
+ * Open a Particle USB device with the specified ID.
+ *
+ * @param {String} id Device ID.
+ * @param {Object} [options] Options (see {@link DeviceBase#open}).
+ * @return {Promise<Device>}
+ */
 export function openDeviceById(id, options) {
 	return openUsbDeviceById(id, options).then(dev => setDevicePrototype(dev));
 }

--- a/src/result.js
+++ b/src/result.js
@@ -115,6 +115,8 @@ const RESULT_CODE_MESSAGES = RESULT_CODES.reduce((obj, result) => {
 
 /**
  * Request result codes.
+ *
+ * @enum {Number}
  */
 export const Result = RESULT_CODES.reduce((obj, result) => {
 	obj[result.id] = result.value;
@@ -123,6 +125,9 @@ export const Result = RESULT_CODES.reduce((obj, result) => {
 
 /**
  * Return a message for the result code.
+ *
+ * @param {Number} result Result code.
+ * @return {String} Error message.
  */
 export function messageForResultCode(result) {
 	return (RESULT_CODE_MESSAGES[result] || 'Request error');

--- a/src/wifi-device.js
+++ b/src/wifi-device.js
@@ -74,10 +74,16 @@ const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPoi
 });
 
 /**
- * Mixin class for a WiFi device.
+ * Wi-Fi device.
+ *
+ * @deprecated Methods provided by this class are not guaranteed to work with recent versions of
+ *             Device OS and will be removed in future versions of this library.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
  */
-// TODO: Recent versions of Device OS use a different network configuration interface and the
-// methods of this class no longer work
 export const WifiDevice = base => class extends base {
 	/**
 	 * Set the WiFi antenna to use.

--- a/src/wifi-device.js
+++ b/src/wifi-device.js
@@ -76,9 +76,6 @@ const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPoi
 /**
  * Wi-Fi device.
  *
- * @deprecated Methods provided by this class are not guaranteed to work with recent versions of
- *             Device OS and will be removed in future versions of this library.
- *
  * This class is not meant to be instantiated directly. Use {@link getDevices} and
  * {@link openDeviceById} to create device instances.
  *
@@ -87,6 +84,12 @@ const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPoi
 export const WifiDevice = base => class extends base {
 	/**
 	 * Set the WiFi antenna to use.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @param {String} antenna Antenna type.
 	 * @return {Promise}
@@ -100,6 +103,12 @@ export const WifiDevice = base => class extends base {
 	/**
 	 * Get the currently used WiFi antenna.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @return {Promise<String>}
 	 */
 	getWifiAntenna(/* antenna */) {
@@ -110,6 +119,12 @@ export const WifiDevice = base => class extends base {
 
 	/**
 	 * Perform the WiFi scan.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<Array>}
 	 */
@@ -125,6 +140,12 @@ export const WifiDevice = base => class extends base {
 	/**
 	 * Set the WiFi credentials.
 	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
 	 * @param {Object} credentials Credentials.
 	 * @return {Promise}
 	 */
@@ -136,6 +157,12 @@ export const WifiDevice = base => class extends base {
 
 	/**
 	 * Get the WiFi credentials.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise<Array>}
 	 */
@@ -150,6 +177,12 @@ export const WifiDevice = base => class extends base {
 
 	/**
 	 * Clear the WiFi credentials.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
 	 *
 	 * @return {Promise}
 	 */


### PR DESCRIPTION
This PR adds missing documentation for the API method parameters, as well as adds info on minimum required Device OS versions and marks deprecated and inconsistently supported methods as `@deprecated`.
