### PR TITLE
feature/ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,74 @@
+name: CICD
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    name: Test (Node.js v${{ matrix.node_version }})
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        experimental:
+          - false
+        node_version:
+          - 8
+          - 10
+          - 12
+        include:
+          - node_version: 14
+            experimental: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: 'npm'
+      - name: Install npm v6
+        if: ${{ matrix.node_version >= 15 }}
+        run: |
+          npm install -g npm@6
+      - name: Install Dependencies
+        run: |
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+          npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Run Tests
+        run: |
+          npm test
+          npm run build:web
+  publish:
+    name: Publish (maybe)
+    runs-on: ubuntu-latest
+    needs: test
+    if: |
+      startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          cache: 'npm'
+      - name: Install Dependencies
+        run: |
+          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+          npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build & Publish Packages
+        run: |
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,15 @@
 # Releasing a new version
 
-- Checkout the `master` branch.
+Packages are only released from the `master` branch after peer review.
 
-- `npm version <major | minor | patch>`
+1. make sure you have the latest:
+	* `$ git checkout master`
+	* `$ git pull`
+2. make sure tests pass
+	* `$ npm test`
+3. bump the version
+	* `$ npm version <major|minor|patch>`
+4. push your tags:
+	* `$ git push origin main --follow-tags`
 
-  - This will bump the version in `package.json`, update the reference docs, and make a version commit and a tag for you.
-
-- `git push && git push --tags`
-
-  - Travis will publish to npm when the build succeeds.
+_CI will publish to npm when the build succeeds_


### PR DESCRIPTION
## Description

Replace TravisCI w/ Github Actions to reenable publishing to `npm`


## How to Test

1. Pull down this branch (`git pull && git checkout feature/ci`)
2. Reinstall dependencies (`npm ci`)
3. Run tests (`npm test`)
4. Review the outcome of CI in https://github.com/particle-iot/particle-usb/actions
5. Review the [docs for releasing](https://github.com/particle-iot/particle-usb/blob/feature/ci/RELEASE.md)

**Outcome**

Tests run successfully in Github Actions, docs are clear 👍 
