### PR TITLE
feature/sc-89893/device-constants-as-peerdependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,9 +1528,10 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.0.tgz",
-      "integrity": "sha512-iVmXQgcB6sIoX19DQKeAPsBaxIAhgXYpS7hQOs0LyZzrH4R9KKBfqEz/Ge6iF2iIZ6I1YU79rnGebVKZcZi22w=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.1.tgz",
+      "integrity": "sha512-2WXzDC749vosH8xWIAJ1KGt/a3WzJEq1qabHcZSIaYrEmRgYTcY2ndqD643ivX9dNT1Uqpzpm348PnBAQjJ7wQ==",
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,13 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.10.2",
-    "@particle/device-constants": "^1.0.0",
     "ip": "^1.1.5",
     "protobufjs": "^6.8.9",
     "usb": "^1.6.2",
     "verror": "^1.10.0"
+  },
+  "peerDependencies": {
+    "@particle/device-constants": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",
@@ -53,6 +55,7 @@
     "@babel/polyfill": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.10.1",
+    "@particle/device-constants": "^1.0.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",


### PR DESCRIPTION
## Description

Makes `@particle/device-constants` a peer dependency so consuming apps are able to manage the dependency and updates are generally easier


## How to Test

1. Pull down this branch (`git pull && git checkout feature/sc-89893/device-constants-as-peerdependency`)
2. Reinstall dependencies (`npm run reinstall`)
3. Run tests (`npm test`)

**Outcome**

Dependencies install successfully, lockfile shows no edits, and tests pass 👍


## Related / Discussions

https://app.shortcut.com/particle/story/89893/particle-usb-supports-tron-platform
https://app.shortcut.com/particle/epic/88674/tron-platform-support