### PR TITLE
bug/ci-npm-publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: false
       matrix:
         experimental:
           - false
@@ -29,6 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
+          registry-url: 'https://registry.npmjs.org'
           node-version: ${{ matrix.node_version }}
           cache: 'npm'
       - name: Install npm v6
@@ -37,10 +37,9 @@ jobs:
           npm install -g npm@6
       - name: Install Dependencies
         run: |
-          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
           npm ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Run Tests
         run: |
           npm test
@@ -56,14 +55,14 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
+          registry-url: 'https://registry.npmjs.org'
           node-version: '12'
           cache: 'npm'
       - name: Install Dependencies
         run: |
-          npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
           npm ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build & Publish Packages
         run: |
           npm publish


### PR DESCRIPTION
## Description

Adds configuration settings required in order to set npm's auth token in CICD (see [error](https://github.com/particle-iot/particle-usb/runs/4304444215?check_suite_focus=true#step:5:122))


## How to Test

1. Pull down this branch (`git pull && git bug/ci-npm-publish`)
2. Reinstall dependencies (`npm ci`)
3. Run tests (`npm test`)
4. Review the outcome of CI in https://github.com/particle-iot/particle-usb/actions

**Outcome**

Tests run successfully in Github Actions, docs are clear 👍

## Related / Discussions

https://github.com/particle-iot/particle-usb/pull/45