### PR TITLE
add support for controlOutTransfersRequireDataStage quirk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,9 +1528,9 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.0.1.tgz",
-      "integrity": "sha512-2WXzDC749vosH8xWIAJ1KGt/a3WzJEq1qabHcZSIaYrEmRgYTcY2ndqD643ivX9dNT1Uqpzpm348PnBAQjJ7wQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.2.0.tgz",
+      "integrity": "sha512-q3G7rwW7UN5C/irg8bIptfmdEayhgQvGm9wKA+g1QgLcrCzvddByWrWxXSJh3m3q8m0NDJBPY0DnG1gDYOQXfw==",
       "dev": true
     },
     "@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "verror": "^1.10.0"
   },
   "peerDependencies": {
-    "@particle/device-constants": "^1.0.0"
+    "@particle/device-constants": "^1.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.1",
@@ -55,7 +55,7 @@
     "@babel/polyfill": "^7.10.1",
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.10.1",
-    "@particle/device-constants": "^1.0.1",
+    "@particle/device-constants": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -103,9 +103,6 @@ export class DeviceBase extends EventEmitter {
 		this._fwVer = null; // Firmware version
 		this._id = null; // Device ID
 		this._dfu = null; // DFU class implementation
-
-		// Apply device quirks
-		this._dev.quirks = this._info.quirks;
 	}
 
 	/**
@@ -118,6 +115,9 @@ export class DeviceBase extends EventEmitter {
 	 * @return {Promise}
 	 */
 	open(options) {
+		// Apply device quirks
+		this._dev.quirks = this._info.quirks;
+
 		options = Object.assign({
 			concurrentRequests: null // The maximum number of concurrent requests is limited by the device
 		}, options);
@@ -347,6 +347,13 @@ export class DeviceBase extends EventEmitter {
 	 */
 	get usbDevice() {
 		return this._dev;
+	}
+
+	/**
+	 * Device USB quirks
+	 */
+	get quirks() {
+		return this._info.quirks;
 	}
 
 	_process() {

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -9,7 +9,7 @@ import EventEmitter from 'events';
 
 // Platforms arranged by vendor/product IDs
 const PLATFORM_USB_IDS = PLATFORMS.reduce((obj, platform) => {
-	const addMapping = (obj, { vendorId, productId }, dfu) => {
+	const addMapping = (obj, { vendorId, productId, quirks }, dfu) => {
 		if (!vendorId) {
 			return;
 		}
@@ -21,7 +21,8 @@ const PLATFORM_USB_IDS = PLATFORMS.reduce((obj, platform) => {
 			id: platform.id,
 			vendorId,
 			productId,
-			dfu
+			dfu,
+			quirks
 		};
 	};
 
@@ -102,6 +103,9 @@ export class DeviceBase extends EventEmitter {
 		this._fwVer = null; // Firmware version
 		this._id = null; // Device ID
 		this._dfu = null; // DFU class implementation
+
+		// Apply device quirks
+		this._dev.quirks = this._info.quirks;
 	}
 
 	/**

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -12,11 +12,12 @@ PLATFORMS.forEach((platform) => {
 });
 
 // Convert the "0x2b04" id strings to 0x2b04 numbers
-function parseIds({ vendorId, productId }) {
-	return {
+function parseIds({ vendorId, productId, quirks }) {
+	return Object.assign({
 		vendorId: Number(vendorId),
-		productId: Number(productId)
-	};
+		productId: Number(productId),
+		quirks: quirks || {}
+	});
 }
 
 function clone(x) {

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -4,20 +4,20 @@ export const PLATFORMS = Object.values(clone(deviceConstants)); // TODO: (Julien
 
 PLATFORMS.forEach((platform) => {
 	if (platform.usb) {
-		platform.usb = parseIds(platform.usb);
+		platform.usb = parseUsbInfo(platform.usb);
 	}
 	if (platform.dfu) {
-		platform.dfu = parseIds(platform.dfu);
+		platform.dfu = parseUsbInfo(platform.dfu);
 	}
 });
 
 // Convert the "0x2b04" id strings to 0x2b04 numbers
-function parseIds({ vendorId, productId, quirks }) {
-	return Object.assign({
+function parseUsbInfo({ vendorId, productId, quirks }) {
+	return {
 		vendorId: Number(vendorId),
 		productId: Number(productId),
 		quirks: quirks || {}
-	});
+	};
 }
 
 function clone(x) {

--- a/src/usb-device-webusb.js
+++ b/src/usb-device-webusb.js
@@ -44,6 +44,7 @@ export class UsbDevice {
 	constructor(dev) {
 		this._dev = dev;
 		this._dev.timeout = 5000; // Use longer timeout for control transfers
+		this._quirks = {};
 	}
 
 	async open() {
@@ -79,6 +80,9 @@ export class UsbDevice {
 
 	async transferOut(setup, data) {
 		try {
+			if (!data && this._quirks.controlOutTransfersRequireDataStage) {
+				data = Buffer.alloc(1);
+			}
 			await this._dev.controlTransferOut({
 				requestType: bmRequestTypeToString(setup.bmRequestType),
 				recipient: bmRequestTypeToRecipientString(setup.bmRequestType),
@@ -133,6 +137,14 @@ export class UsbDevice {
 
 	get internalObject() {
 		return this._dev;
+	}
+
+	get quirks() {
+		return this._quirks;
+	}
+
+	set quirks(qs) {
+		this._quirks = qs;
 	}
 }
 

--- a/test/integration/device-quirks.js
+++ b/test/integration/device-quirks.js
@@ -1,0 +1,40 @@
+import { getDevices } from '../../src/particle-usb';
+
+import { expect, integrationTest } from '../support';
+
+describe('device-quirks', function desc() {
+	// Cellular device operations may take a while
+	this.timeout(60000);
+	this.slow(45000);
+
+	let devs = [];
+	let dev = null;
+
+	before(function setup() {
+		return integrationTest(this, async () => {
+			devs = await getDevices();
+			if (!devs.length) {
+				throw new Error('This test suite requires at least one device');
+			}
+			dev = devs[0];
+		});
+	});
+
+	afterEach(async () => {
+		for (let dev of devs) {
+			await dev.close();
+		}
+	});
+
+    describe('controlOutTransfersRequireDataStage', () => {
+        it('disconnectFromCloud() does not timeout', async () => {
+            await dev.open();
+            // Force controlOutTransfersRequireDataStage quirk
+            let quirks = dev.usbDevice.quirks;
+            quirks.controlOutTransfersRequireDataStage = true;
+            dev.usbDevice.quirks = quirks;
+            // This is one of the requests without a data stage
+            await dev.disconnectFromCloud({force: true});
+        });
+    });
+});


### PR DESCRIPTION
Some platforms have non-compliant behavior where control OUT (Host to Device) transfers over EP0 always require a data stage to be present even if setup request has wLength=0, otherwise the request does not complete and times out.

@sergeuz Any suggestions on unit tests for this?

See also https://github.com/particle-iot-inc/device-constants/pull/12