### PR TITLE
Limit version of node-usb to avoid broken 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/runtime-corejs2": "^7.10.2",
     "ip": "^1.1.5",
     "protobufjs": "^6.8.9",
-    "usb": "^1.6.2",
+    "usb": "<= 1.6.2",
     "verror": "^1.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
#47 notes that node-usb 1.9.1 causes issues. Since the version is currently open-ended `^1.6.2`, installing `particle-usb` also updates to node-usb 1.9.1.

This is a temporary fix until node-usb fixes the bug, then we can go back to an open ended version in #47.