### PR TITLE
feature/sc-91835/node-usb-binaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,6 +1953,12 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -4031,6 +4037,18 @@
       "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -5318,6 +5336,16 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsonparse": {
@@ -8969,6 +8997,12 @@
       "requires": {
         "unist-util-is": "^3.0.0"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "documentation": "^12.3.0",
     "eslint": "^6.8.0",
     "eslint-config-particle": "^2.5.0",
+    "fs-extra": "^9.1.0",
     "mkdirp": "^1.0.4",
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "protobufjs": "^6.11.2",
-    "usb": "^1.9.2"
+    "usb": "1.9.2"
   },
   "peerDependencies": {
     "@particle/device-constants": "^1.2.0"

--- a/test/integration/package.js
+++ b/test/integration/package.js
@@ -1,0 +1,63 @@
+const path = require('path');
+const fs = require('fs-extra');
+const { expect } = require('../support');
+
+
+describe('package artifacts', () => {
+	const pathToNodeUSB = path.dirname(require.resolve('usb/package.json'));
+	const pathToBinaries = path.join(pathToNodeUSB, 'prebuilds');
+	const specs = [
+		{
+			platform: 'darwin-x64+arm64',
+			files: [
+				'node.napi.node'
+			]
+		},
+		{
+			platform: 'linux-arm',
+			files: [
+				'node.napi.armv6.node',
+				'node.napi.armv7.node'
+			]
+		},
+		{
+			platform: 'linux-arm64',
+			files: [
+				'node.napi.armv8.node'
+			]
+		},
+		{
+			platform: 'linux-x64',
+			files: [
+				'node.napi.glibc.node',
+				'node.napi.musl.node'
+			]
+		},
+		{
+			platform: 'win32-ia32',
+			files: [
+				'node.napi.node'
+			]
+		},
+		{
+			platform: 'win32-x64',
+			files: [
+				'node.napi.node'
+			]
+		}
+	];
+
+	specs.forEach((spec, index) => {
+		const { platform, files } = spec;
+
+		it(`includes node-usb binary for: '${platform}' [spec: ${index}]`, async () => {
+			for (const file of files){
+				const filename = path.join(pathToBinaries, platform, file);
+				const exists = await fs.pathExists(filename);
+
+				expect(exists).to.equal(true, `Not found: ${filename}`);
+			}
+		});
+	});
+});
+


### PR DESCRIPTION
## Description

Adds integration tests to verify [`node-usb`](https://github.com/node-usb/node-usb) dependency includes the prebuilt binaries required by Particle developer tools. 


## How to Test

1. Pull down this branch (`git pull && git feature/sc-91835/node-usb-binaries`)
2. Reinstall dependencies (`npm ci`)
3. Run tests (`npm test`)

**Outcome**

Tests run successfully, assertions are clear 👍


## Related / Discussions

https://app.shortcut.com/particle/story/91835/cut-a-first-release-of-mfg-cli-that-handles-packages-with-native-dependencies-correctly