### PR TITLE
Complete implementation and cut particle-usb@2.1.0 (scan wifi networks, join one, clear wifi networks)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "prepublish": "git submodule update --init && npm run build",
     "version": "npm run docs && git add docs",
-    "test": "mocha test test/integration",
+    "test": "mocha test test/integration './src/**/*.test.js'",
     "test:ci": "npm run lint && npm test && npm run coverage",
     "test:silent": "PARTICLE_NOOP=$(npm run test)",
     "lint": "eslint . --ext .js --ignore-path .gitignore",

--- a/src/cellular-device.test.js
+++ b/src/cellular-device.test.js
@@ -1,0 +1,11 @@
+const { /*sinon,*/ expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+
+describe('CellularDevice', () => {
+	it('provides getIccid() for Particle boron', async () => {
+		// TODO: Pull from platforms like code does
+		const fakeDevice = { type: 'boron' };
+		const result = setDevicePrototype(fakeDevice);
+		expect(result.getIccid).to.be.a('Function');
+	});
+});

--- a/src/cloud-device.test.js
+++ b/src/cloud-device.test.js
@@ -1,0 +1,29 @@
+const { /*sinon,*/ expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+
+describe('CloudDevice', () => {
+	it('provides CloudDevice methods in cloud-device.js (which ALL Particle Devices inherit from)', async () => {
+		const cloudDeviceInterface = [
+			'connectToCloud',
+			'disconnectFromCloud',
+			'getCloudConnectionStatus',
+			'setClaimCode',
+			'isClaimed',
+			'setDevicePrivateKey', // deprecated
+			'getDevicePrivateKey', // deprecated
+			'setDevicePublicKey', // deprecated
+			'getDevicePublicKey', // deprecated
+			'setServerPublicKey', // deprecated
+			'getServerPublicKey', // deprecated
+			'setServerAddress', // deprecated
+			'getServerAddress', // deprecated
+			'setServerProtocol', // deprecated
+		];
+		const fakeDevice = { type: 'p2' };
+		const result = setDevicePrototype(fakeDevice);
+		for (const func of cloudDeviceInterface) {
+			expect(result[func]).to.be.a('Function');
+		}
+	});
+});
+

--- a/src/device-base.test.js
+++ b/src/device-base.test.js
@@ -1,12 +1,12 @@
-const { fakeUsb, sinon, expect, assert, nextTick } = require('./support');
+const { fakeUsb, sinon, expect, assert, nextTick } = require('../test/support');
 const proxyquire = require('proxyquire');
 
 const { getDevices, openDeviceById, PollingPolicy } = proxyquire('../src/device-base', {
 	'./usb-device-node': fakeUsb
 });
-const usbImpl = require('../src/usb-device-node');
-const proto = require('../src/usb-protocol');
-const error = require('../src/error');
+const usbImpl = require('./usb-device-node');
+const proto = require('./usb-protocol');
+const error = require('./error');
 
 // Application-specific request types
 const REQUEST_1 = 1;

--- a/src/device.test.js
+++ b/src/device.test.js
@@ -3,15 +3,15 @@
  * which is the object under test in this file. Instead, we take a different mocking
  * strategy that also mocks out USB hardware, but doesn't mock src/device.js.
  */
-const { sinon, expect } = require('./support');
-const { UsbDevice } = require('../src/usb-device-node');
-const { PLATFORMS } = require('../src/platforms');
-const { Device } = require('../src/device');
+const { sinon, expect } = require('../test/support');
+const { UsbDevice } = require('./usb-device-node');
+const { PLATFORMS } = require('./platforms');
+const { Device } = require('./device');
 const DeviceOSProtobuf = require('@particle/device-os-protobuf');
-const { Result } = require('../src/result');
-const { RequestError } = require('../src/error');
+const { Result } = require('./result');
+const { RequestError } = require('./error');
 
-describe('Control Requests', () => {
+describe('Device', () => {
 	const exampleSerialNumber = 'P046AF1450000FC';
 	let usbDevice, p2Platform, device;
 	beforeEach(async () => {

--- a/src/gen3-device.test.js
+++ b/src/gen3-device.test.js
@@ -1,0 +1,22 @@
+const { sinon, expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+
+describe('Gen3Device', () => {
+	beforeEach(() => { });
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	it('provides setSetupDone() function for argon', async () => {
+		const fakeDevice = { type: 'argon' };
+		const result = setDevicePrototype(fakeDevice);
+		expect(result.setSetupDone).to.be.a('Function');
+	});
+
+	it('provides setSetupDone() function for boron', async () => {
+		const fakeDevice = { type: 'boron' };
+		const result = setDevicePrototype(fakeDevice);
+		expect(result.setSetupDone).to.be.a('Function');
+	});
+});

--- a/src/network-device.test.js
+++ b/src/network-device.test.js
@@ -1,5 +1,12 @@
-describe('NetworkDevice', () => {
-	it('contains all deprecated methods	(getNetworkStatus, getNetworkConfig, setNetworkConfig) that are not worth testing', async () => {
-
-	});
+const { expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+describe('NetworkDevice (all deprecated methods)', () => {
+	const deprecatedMethods = ['getNetworkStatus', 'getNetworkConfig', 'setNetworkConfig'];
+	for (const method of deprecatedMethods) {
+		it(`provides ${method}`, async () => {
+			const fakeDevice = { type: 'p2' }; // could be any device type
+			const result = setDevicePrototype(fakeDevice);
+			expect(result[method]).to.be.a('Function');
+		});
+	}
 });

--- a/src/network-device.test.js
+++ b/src/network-device.test.js
@@ -1,0 +1,5 @@
+describe('NetworkDevice', () => {
+	it('contains all deprecated methods	(getNetworkStatus, getNetworkConfig, setNetworkConfig) that are not worth testing', async () => {
+
+	});
+});

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -1,11 +1,4 @@
 const { getDevices: getUsbDevices, openDeviceById: openUsbDeviceById } = require('./device-base');
-const { PLATFORMS } = require('./platforms');
-const { Device } = require('./device');
-const { WifiDevice } = require('./wifi-device');
-const { CellularDevice } = require('./cellular-device');
-const { CloudDevice } = require('./cloud-device');
-const { Gen3Device } = require('./gen3-device');
-const { NetworkDevice } = require('./network-device');
 const { PollingPolicy } = require('./device-base');
 const { FirmwareModule } = require('./device');
 const { NetworkStatus } = require('./network-device');
@@ -14,33 +7,7 @@ const { CloudConnectionStatus, ServerProtocol } = require('./cloud-device');
 const { Result } = require('./result');
 const { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError, InternalError, RequestError } = require('./error');
 const { config } = require('./config');
-
-// Create a class for each platform by mixing in different capabilities
-const DEVICE_PROTOTYPES = PLATFORMS.reduce((prototypes, platform) => {
-	let klass = class extends NetworkDevice(Device) {};
-	if (platform.generation === 3) {
-		klass = class extends Gen3Device(klass) {};
-	}
-	if (platform.features.includes('cellular')) {
-		klass = class extends CellularDevice(klass) {};
-	}
-	if (platform.features.includes('wifi')) {
-		klass = class extends WifiDevice(klass) {};
-	}
-	klass = class extends CloudDevice(klass) {};
-
-	prototypes[platform.name] = klass.prototype;
-
-	return prototypes;
-}, {});
-
-function setDevicePrototype(dev) {
-	const proto = DEVICE_PROTOTYPES[dev.type];
-	if (!proto) {
-		return dev;
-	}
-	return Object.setPrototypeOf(dev, proto);
-}
+const { setDevicePrototype } = require('./set-device-prototype');
 
 /**
  * Enumerate Particle USB devices attached to the host.

--- a/src/particle-usb.test.js
+++ b/src/particle-usb.test.js
@@ -1,0 +1,36 @@
+const { /*sinon*/ expect } = require('../test/support');
+const particleUSB = require('./particle-usb');
+describe('Public interface of npm module', () => {
+	it('exports expected stuff', () => {
+		expect(particleUSB.getDevices).to.be.a('Function');
+		expect(particleUSB.openDeviceById).to.be.a('Function');
+		expect(particleUSB.PollingPolicy).to.be.an('object');
+		expect(particleUSB.PollingPolicy.DEFAULT).to.be.a('Function');
+
+		// Deliberately, omitting a lot of stuff below that is true below
+		// Given device-os-protobuf/DeviceOSProtobuf.getDefinition(), why do we need to export this stuff?
+		// expect(particleUSB.FirmwareModule).to.be.an('object');
+		// expect(particleUSB.FirmwareModule.BOOTLOADER).to.eql('BOOTLOADER');
+		// expect(particleUSB.FirmwareModule.SYSTEM_PART).to.eql('SYSTEM_PART');
+		// expect(particleUSB.FirmwareModule.USER_PART).to.eql('USER_PART');
+		// expect(particleUSB.FirmwareModule.MONO_FIRMWARE).to.eql('MONO_FIRMWARE');
+		// expect(particleUSB.NetworkStatus).to.be.an('object');
+		// expect(particleUSB.WifiAntenna).to.be.an('object');
+		// expect(particleUSB.WifiCipher).to.be.an('object');
+		// expect(particleUSB.EapMethod).to.be.an('object');
+
+		expect(particleUSB.CloudConnectionStatus).to.be.an('object');
+		expect(particleUSB.Result).to.be.an('object');
+		expect(particleUSB.DeviceError).to.be.a('Function');
+		expect(particleUSB.NotFoundError).to.be.a('Function');
+		expect(particleUSB.NotAllowedError).to.be.a('Function');
+		expect(particleUSB.StateError).to.be.a('Function');
+		expect(particleUSB.TimeoutError).to.be.a('Function');
+		expect(particleUSB.MemoryError).to.be.a('Function');
+		expect(particleUSB.ProtocolError).to.be.a('Function');
+		expect(particleUSB.UsbError).to.be.a('Function');
+		expect(particleUSB.InternalError).to.be.a('Function');
+		expect(particleUSB.RequestError).to.be.a('Function');
+		expect(particleUSB.config).to.be.a('Function');
+	});
+});

--- a/src/particle-usb.test.js
+++ b/src/particle-usb.test.js
@@ -1,7 +1,7 @@
 const { /*sinon*/ expect } = require('../test/support');
 const particleUSB = require('./particle-usb');
 describe('Public interface of npm module', () => {
-	it('exports expected stuff', () => {
+	it('exports expected objects and functions', () => {
 		expect(particleUSB.getDevices).to.be.a('Function');
 		expect(particleUSB.openDeviceById).to.be.a('Function');
 		expect(particleUSB.PollingPolicy).to.be.an('object');

--- a/src/set-device-prototype.js
+++ b/src/set-device-prototype.js
@@ -1,0 +1,60 @@
+/**
+ * A function that determines the the class and inheritance hierarchy
+ * of a Particle USB device based on it's platform characteristics
+ */
+const { PLATFORMS } = require('./platforms');
+const { Device } = require('./device');
+const { WifiDevice } = require('./wifi-device');
+const { CellularDevice } = require('./cellular-device');
+const { CloudDevice } = require('./cloud-device');
+const { Gen3Device } = require('./gen3-device');
+const { NetworkDevice } = require('./network-device');
+
+/**
+ * returns a structure like this:
+//   core: klass {},
+//   gcc: klass {},
+//   photon: klass {},
+//   p1: klass {},
+//   electron: klass {},
+//   argon: klass {},
+//   boron: klass {},
+//   p2: klass {},
+//  ...
+// }
+ */
+const DEVICE_PROTOTYPES = PLATFORMS.reduce((prototypes, platform) => {
+	let klass = class extends NetworkDevice(Device) {};
+	if (platform.generation === 3) {
+		klass = class extends Gen3Device(klass) {};
+	}
+	if (platform.features.includes('cellular')) {
+		klass = class extends CellularDevice(klass) {};
+	}
+	if (platform.features.includes('wifi')) {
+		klass = class extends WifiDevice(klass) {};
+	}
+	klass = class extends CloudDevice(klass) {};
+
+	prototypes[platform.name] = klass.prototype;
+
+	return prototypes;
+}, {});
+
+/**
+ *
+ * @param {*} usbDevice - An object with a .type field that is a string like "p1", "argon", "p2", etc
+ * 						  representing the short name of the device platform.
+ * @returns {*} an instance of a class like WifiDevice, CellularDevice with the correct inheritance hierachy
+ */
+function setDevicePrototype(usbDevice) {
+	const proto = DEVICE_PROTOTYPES[usbDevice.type];
+	if (!proto) {
+		return usbDevice;
+	}
+	return Object.setPrototypeOf(usbDevice, proto);
+}
+
+module.exports = {
+	setDevicePrototype
+};

--- a/src/set-device-prototype.js
+++ b/src/set-device-prototype.js
@@ -1,26 +1,18 @@
-/**
- * A function that determines the the class and inheritance hierarchy
- * of a Particle USB device based on it's platform characteristics
- */
 const { PLATFORMS } = require('./platforms');
 const { Device } = require('./device');
 const { WifiDevice } = require('./wifi-device');
+const { WifiDeviceLegacy } = require('./wifi-device-legacy');
 const { CellularDevice } = require('./cellular-device');
 const { CloudDevice } = require('./cloud-device');
 const { Gen3Device } = require('./gen3-device');
 const { NetworkDevice } = require('./network-device');
 
 /**
- * returns a structure like this:
-//   core: klass {},
-//   gcc: klass {},
+ * This constant has a structure like this:
 //   photon: klass {},
-//   p1: klass {},
 //   electron: klass {},
-//   argon: klass {},
-//   boron: klass {},
 //   p2: klass {},
-//  ...
+//   ...
 // }
  */
 const DEVICE_PROTOTYPES = PLATFORMS.reduce((prototypes, platform) => {
@@ -32,7 +24,11 @@ const DEVICE_PROTOTYPES = PLATFORMS.reduce((prototypes, platform) => {
 		klass = class extends CellularDevice(klass) {};
 	}
 	if (platform.features.includes('wifi')) {
-		klass = class extends WifiDevice(klass) {};
+		if (platform.generation === 2 || platform.generation === 1) {
+			klass = class extends WifiDeviceLegacy(klass) {};
+		} else {
+			klass = class extends WifiDevice(klass) {};
+		}
 	}
 	klass = class extends CloudDevice(klass) {};
 
@@ -42,7 +38,8 @@ const DEVICE_PROTOTYPES = PLATFORMS.reduce((prototypes, platform) => {
 }, {});
 
 /**
- *
+ * Determines the the class and inheritance hierarchy
+ * of a Particle USB device based on it's platform characteristics *
  * @param {*} usbDevice - An object with a .type field that is a string like "p1", "argon", "p2", etc
  * 						  representing the short name of the device platform.
  * @returns {*} an instance of a class like WifiDevice, CellularDevice with the correct inheritance hierachy

--- a/src/set-device-prototype.test.js
+++ b/src/set-device-prototype.test.js
@@ -1,84 +1,25 @@
 const { sinon, expect } = require('../test/support');
 const { setDevicePrototype } = require('./set-device-prototype');
 const { Device } = require('./device');
-// The methods we assert are defined in these files, but we don't include
-// them because uncertainty with how to assert an instance has a given
-// mixin mixed in.
-//   const { WifiDevice } = require('./wifi-device');
-//   const { CellularDevice } = require('./cellular-device');
-//   const { CloudDevice } = require('./cloud-device');
-//   const { Gen3Device } = require('./gen3-device');
-//   const { NetworkDevice } = require('./network-device');
+const { PLATFORMS } = require('./platforms');
 
-describe('setDevicePrototype(), a helper function that sets prototype and inheritance hierarchy based on platform characteristics', () => {
+describe('setDevicePrototype(), a helper function that sets prototype and inheritance hierarchy based on hardware platform', () => {
+	let relevantPlatformNames;
 	beforeEach(() => {
-
+		relevantPlatformNames = PLATFORMS.map(x => x.name);
 	});
 
 	afterEach(() => {
 		sinon.restore();
 	});
 
-	// TODO: this will become wifi-device-legacy.js
-	it('provides functions for gen2 wifi devices (Photon) in wifi-device.js', async () => {
-		const wifiDeviceInterface = [
-			'setWifiAntenna', // deprecated
-			'getWifiAntenna', // deprecated
-			'scanWifiNetworks', // will be updated
-			'setWifiCredentials', // deprecated
-			'getWifiCredentials', // deprecated
-			'clearWifiCredentials', // deprecated
-		];
-		const fakeDevice = { type: 'photon'	};
-		const result = setDevicePrototype(fakeDevice);
-		expect(result).to.be.an.instanceOf(Device);
-
-		// Note: this does NOT work because this is a Mixin rather than parent class
-		//   expect(result).to.be.an.instanceOf(WifiDevice);
-		// Instead, we assert the public methods that this thing exported:
-		for (const func of wifiDeviceInterface) {
-			expect(result[func]).to.be.a('Function');
-		}
-	});
-
-	it('provides setSetupDone() function for gen3 devices (Argon, Boron) in gen3-device.js', async () => {
-		const fakeDevice = { type: 'argon'	};
-		const result = setDevicePrototype(fakeDevice);
-		expect(result).to.be.an.instanceOf(Device);
-		expect(result.setSetupDone).to.be.a('Function');
-	});
-
-	// Note: Deliberately skipping assertions against NetworkDevice, which has all deprecated methods
-
-	it('provides getIccid() for cellular devices (Electron, Boron) in cellular-device.js', async () => {
-		const fakeDevice = { type: 'boron'	};
-		const result = setDevicePrototype(fakeDevice);
-		expect(result).to.be.an.instanceOf(Device);
-		expect(result.getIccid).to.be.a('Function');
-	});
-
-	it('provides CloudDevice methods in cloud-device.js (which ALL Particle Devices inherit from)', async () => {
-		const cloudDeviceInterface = [
-			'connectToCloud',
-			'disconnectFromCloud',
-			'getCloudConnectionStatus',
-			'setClaimCode',
-			'isClaimed',
-			'setDevicePrivateKey', // deprecated
-			'getDevicePrivateKey', // deprecated
-			'setDevicePublicKey', // deprecated
-			'getDevicePublicKey', // deprecated
-			'setServerPublicKey', // deprecated
-			'getServerPublicKey', // deprecated
-			'setServerAddress', // deprecated
-			'getServerAddress', // deprecated
-			'setServerProtocol', // deprecated
-		];
-		const fakeDevice = { type: 'p2'	};
-		const result = setDevicePrototype(fakeDevice);
-		expect(result).to.be.an.instanceOf(Device);
-		for (const func of cloudDeviceInterface) {
-			expect(result[func]).to.be.a('Function');
+	// See platform specific mixins like wifi-device.test.js for specific assertions
+	// against method implementations
+	it('returns a Device instance for all platforms', () => {
+		for (const platformName of relevantPlatformNames) {
+			const fakeDevice = { type: platformName };
+			const result = setDevicePrototype(fakeDevice);
+			expect(result).to.be.an.instanceOf(Device);
 		}
 	});
 });

--- a/src/set-device-prototype.test.js
+++ b/src/set-device-prototype.test.js
@@ -1,0 +1,84 @@
+const { sinon, expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+const { Device } = require('./device');
+// The methods we assert are defined in these files, but we don't include
+// them because uncertainty with how to assert an instance has a given
+// mixin mixed in.
+//   const { WifiDevice } = require('./wifi-device');
+//   const { CellularDevice } = require('./cellular-device');
+//   const { CloudDevice } = require('./cloud-device');
+//   const { Gen3Device } = require('./gen3-device');
+//   const { NetworkDevice } = require('./network-device');
+
+describe('setDevicePrototype(), a helper function that sets prototype and inheritance hierarchy based on platform characteristics', () => {
+	beforeEach(() => {
+
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	// TODO: this will become wifi-device-legacy.js
+	it('provides functions for gen2 wifi devices (Photon) in wifi-device.js', async () => {
+		const wifiDeviceInterface = [
+			'setWifiAntenna', // deprecated
+			'getWifiAntenna', // deprecated
+			'scanWifiNetworks', // will be updated
+			'setWifiCredentials', // deprecated
+			'getWifiCredentials', // deprecated
+			'clearWifiCredentials', // deprecated
+		];
+		const fakeDevice = { type: 'photon'	};
+		const result = setDevicePrototype(fakeDevice);
+		expect(result).to.be.an.instanceOf(Device);
+
+		// Note: this does NOT work because this is a Mixin rather than parent class
+		//   expect(result).to.be.an.instanceOf(WifiDevice);
+		// Instead, we assert the public methods that this thing exported:
+		for (const func of wifiDeviceInterface) {
+			expect(result[func]).to.be.a('Function');
+		}
+	});
+
+	it('provides setSetupDone() function for gen3 devices (Argon, Boron) in gen3-device.js', async () => {
+		const fakeDevice = { type: 'argon'	};
+		const result = setDevicePrototype(fakeDevice);
+		expect(result).to.be.an.instanceOf(Device);
+		expect(result.setSetupDone).to.be.a('Function');
+	});
+
+	// Note: Deliberately skipping assertions against NetworkDevice, which has all deprecated methods
+
+	it('provides getIccid() for cellular devices (Electron, Boron) in cellular-device.js', async () => {
+		const fakeDevice = { type: 'boron'	};
+		const result = setDevicePrototype(fakeDevice);
+		expect(result).to.be.an.instanceOf(Device);
+		expect(result.getIccid).to.be.a('Function');
+	});
+
+	it('provides CloudDevice methods in cloud-device.js (which ALL Particle Devices inherit from)', async () => {
+		const cloudDeviceInterface = [
+			'connectToCloud',
+			'disconnectFromCloud',
+			'getCloudConnectionStatus',
+			'setClaimCode',
+			'isClaimed',
+			'setDevicePrivateKey', // deprecated
+			'getDevicePrivateKey', // deprecated
+			'setDevicePublicKey', // deprecated
+			'getDevicePublicKey', // deprecated
+			'setServerPublicKey', // deprecated
+			'getServerPublicKey', // deprecated
+			'setServerAddress', // deprecated
+			'getServerAddress', // deprecated
+			'setServerProtocol', // deprecated
+		];
+		const fakeDevice = { type: 'p2'	};
+		const result = setDevicePrototype(fakeDevice);
+		expect(result).to.be.an.instanceOf(Device);
+		for (const func of cloudDeviceInterface) {
+			expect(result[func]).to.be.a('Function');
+		}
+	});
+});

--- a/src/wifi-device-legacy.js
+++ b/src/wifi-device-legacy.js
@@ -1,0 +1,205 @@
+/**
+ * All of the functionality in this class is deprecated.
+ * However, it can still be used on Paticle Photon devices running
+ * Device OS systems firmware from 0.8.0 to pre 2.0.0.
+ */
+const { Request } = require('./request');
+const { fromProtobufEnum, fromProtobufMessage, toProtobufMessage } = require('./protobuf-util');
+
+const proto = require('./protocol');
+
+/**
+ * WiFi antenna types.
+ */
+const WifiAntenna = fromProtobufEnum(proto.WiFiAntenna, {
+	INTERNAL: 'INTERNAL',
+	EXTERNAL: 'EXTERNAL',
+	AUTO: 'AUTO'
+});
+
+/**
+ * WiFi security types.
+ */
+const WifiSecurity = fromProtobufEnum(proto.WiFiSecurityType, {
+	NONE: 'UNSEC',
+	WEP: 'WEP',
+	WPA: 'WPA',
+	WPA2: 'WPA2',
+	WPA_ENTERPRISE: 'WPA_ENTERPRISE',
+	WPA2_ENTERPRISE: 'WPA2_ENTERPRISE',
+	UNKNOWN: 'UNKNOWN'
+});
+
+/**
+ * WiFi cipher types.
+ */
+const WifiCipher = fromProtobufEnum(proto.WiFiSecurityCipher, {
+	AES: 'AES',
+	TKIP: 'TKIP',
+	AES_TKIP: 'AES_TKIP'
+});
+
+/**
+ * EAP methods.
+ */
+const EapMethod = fromProtobufEnum(proto.EapType, {
+	TLS: 'TLS',
+	PEAP: 'PEAP'
+});
+
+function bssidFromProtobuf(bssid) {
+	return [...bssid].map(b => b.toString(16).padStart(2, '0')).join(':');
+}
+
+function bssidToProtobuf(bssid) {
+	return Buffer.from(bssid.replace(/:/g, ''), 'hex');
+}
+
+const accessPointCommonProperties = ['ssid', 'channel', 'maxDataRate', 'rssi', 'password', 'innerIdentity',
+	'outerIdentity', 'privateKey', 'clientCertificate', 'caCertificate'];
+
+const accessPointFromProtobuf = fromProtobufMessage(proto.WiFiAccessPoint, accessPointCommonProperties, {
+	bssid: bssidFromProtobuf,
+	security: WifiSecurity.fromProtobuf,
+	cipher: WifiCipher.fromProtobuf,
+	eapType: {
+		name: 'eapMethod',
+		value: EapMethod.fromProtobuf
+	}
+});
+
+const accessPointToProtobuf = toProtobufMessage(proto.WiFiAccessPoint, accessPointCommonProperties, {
+	bssid: bssidToProtobuf,
+	security: WifiSecurity.toProtobuf,
+	cipher: WifiCipher.toProtobuf,
+	eapMethod: {
+		name: 'eapType',
+		value: EapMethod.toProtobuf
+	}
+});
+
+/**
+ * Wi-Fi device.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ *
+ * @mixin
+ */
+const WifiDeviceLegacy = base => class extends base {
+	/**
+	 * Set the WiFi antenna to use.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @param {String} antenna Antenna type.
+	 * @return {Promise}
+	 */
+	setWifiAntenna(antenna) {
+		return this.sendRequest(Request.WIFI_SET_ANTENNA, {
+			antenna: WifiAntenna.toProtobuf(antenna)
+		});
+	}
+
+	/**
+	 * Get the currently used WiFi antenna.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @return {Promise<String>}
+	 */
+	getWifiAntenna(/* antenna */) {
+		return this.sendRequest(Request.WIFI_GET_ANTENNA).then(rep => {
+			return WifiAntenna.fromProtobuf(rep.antenna);
+		});
+	}
+
+	/**
+	 * Perform the WiFi scan.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @return {Promise<Array>}
+	 */
+	scanWifiNetworks() {
+		return this.sendRequest(Request.WIFI_SCAN).then(rep => {
+			if (!rep.list) {
+				return [];
+			}
+			return rep.list.aps.map(ap => accessPointFromProtobuf(ap));
+		});
+	}
+
+	/**
+	 * Set the WiFi credentials.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @param {Object} credentials Credentials.
+	 * @return {Promise}
+	 */
+	setWifiCredentials(credentials) {
+		return this.sendRequest(Request.WIFI_SET_CREDENTIALS, {
+			ap: accessPointToProtobuf(credentials)
+		});
+	}
+
+	/**
+	 * Get the WiFi credentials.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @return {Promise<Array>}
+	 */
+	getWifiCredentials() {
+		return this.sendRequest(Request.WIFI_GET_CREDENTIALS).then(rep => {
+			if (!rep.list) {
+				return [];
+			}
+			return rep.list.aps.map(ap => accessPointFromProtobuf(ap));
+		});
+	}
+
+	/**
+	 * Clear the WiFi credentials.
+	 *
+	 * @deprecated This method is not guaranteed to work with recent versions of Device OS and it will
+	 *             be removed in future versions of this library.
+	 *
+	 * Supported platforms:
+	 * - Gen 2 (since Device OS 0.8.0, deprecated in 2.0.0)
+	 *
+	 * @return {Promise}
+	 */
+	clearWifiCredentials() {
+		return this.sendRequest(Request.WIFI_CLEAR_CREDENTIALS);
+	}
+};
+
+module.exports = {
+	WifiAntenna,
+	WifiSecurity,
+	WifiCipher,
+	EapMethod,
+	WifiDeviceLegacy
+};

--- a/src/wifi-device-legacy.test.js
+++ b/src/wifi-device-legacy.test.js
@@ -1,0 +1,43 @@
+const { sinon, expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+const { PLATFORMS } = require('./platforms');
+
+describe('WifiDeviceLegacy', () => {
+	let relevantPlatformNames;
+	beforeEach(() => {
+		// default to everything 1 and greater, tests override to be more specific when needed
+		relevantPlatformNames = PLATFORMS
+			.filter(x => x.generation >= 1)
+			.map(x => x.name);
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+	it('provides deprecated wifi functions for core, photon, and p1 devices', async () => {
+		// 'core', 'photon', 'p1'
+		// I doubt this works on Spark Core/gen 1, but why not
+		// Certainly won't work on gen -1/deprecated hardware platforms
+		relevantPlatformNames = PLATFORMS
+			.filter(x => (x.generation === 1 || x.generation === 2) && x.features.includes('wifi'))
+			.map(x => x.name);
+
+		// This id the deprecated interface
+		const wifiDeviceInterface = [
+			'setWifiAntenna', // deprecated
+			'getWifiAntenna', // deprecated
+			'scanWifiNetworks', // deprecated; but updated method provided in new/non legacy WifiDevice
+			'setWifiCredentials', // deprecated
+			'getWifiCredentials', // deprecated
+			'clearWifiCredentials', // deprecated
+		];
+
+		for (const platformName of relevantPlatformNames) {
+			const fakeDevice = { type: platformName };
+			const result = setDevicePrototype(fakeDevice);
+			for (const func of wifiDeviceInterface) {
+				expect(result[func]).to.be.a('Function', `${platformName} implements ${func}`);
+			}
+		}
+	});
+});

--- a/src/wifi-device.js
+++ b/src/wifi-device.js
@@ -57,29 +57,40 @@ const WifiDevice = base => class extends base {
 	/**
 	 * Join a new WiFi network for Gen 3+ devices.
 	 *
-	 * Note, there is a bug in Device OS (sc-96270) where P2's don't do anything with bssid or security fields
-	 * when this bug is fixed the fields will become available on this method
+	 * Note, there are known bugs with this method/Device OS:
+	 *   - sc-96270: where P2's don't do anything with bssid or security fields; so cannot connect to hidden networks
+	 *   - sc-96826: Connecting to open network without passsword does not work
 	 *
 	 * Supported platforms:
 	 * - Gen 4: Supported on P2 since Device OS 3.x
 	 * @param {string} ssid - SSID of Wifi Network
-	 * @param {string} password - Password of Wifi network, pass null to no password
+	 * @param {string} password - Password of Wifi network, if not set will not use security
 	 * @param {Object} options See sendControlRequest(), same options are here.
 	 * @return {ProtobufInteraction} -
 	 */
-	async joinNewWifiNetwork({ ssid, password }, options) {
-		return await this._sendAndHandleProtobufRequest(
-			'wifi.JoinNewNetworkRequest',
-			{
+	async joinNewWifiNetwork({ ssid, password = null }, options) {
+		let dataPayload;
+		if (password === null) {
+			dataPayload = {
 				ssid,
-				// Bug: P2s ignore these right now, so we don't pass them
+				bssid: null,
+				security: 0 // Security.NO_SECURITY
+			};
+			throw new Error('joinNewWifiNetwork() does not currently support connecting to networks without a password/security, sc-TODO');
+		} else {
+			dataPayload = {
+				ssid,
 				bssid: null,
 				security: null,
 				credentials: {
-					type: 1,
+					type: 1, // CredentialsType.PASSWORD
 					password
 				},
-			},
+			};
+		}
+		return await this._sendAndHandleProtobufRequest(
+			'wifi.JoinNewNetworkRequest',
+			dataPayload,
 			options
 		);
 	}

--- a/src/wifi-device.test.js
+++ b/src/wifi-device.test.js
@@ -1,0 +1,32 @@
+const { sinon, expect } = require('../test/support');
+const { setDevicePrototype } = require('./set-device-prototype');
+const { PLATFORMS } = require('./platforms');
+
+describe('WifiDevice', () => {
+	const relevantPlatformNames = PLATFORMS
+		.filter(x => x.generation >= 3 && x.features.includes('wifi'))
+		.map(x => x.name);
+
+	beforeEach(() => {
+
+	});
+
+	afterEach(() => {
+		sinon.restore();
+	});
+
+	for (const platformName of relevantPlatformNames) {
+		it(`provides expected interface for platform=${platformName}`, async () => {
+			const fakeDevice = { type: platformName };
+			const result = setDevicePrototype(fakeDevice);
+			const wifiDeviceInterface = [
+				'scanWifiNetworks',
+				'joinNewWifiNetwork',
+				'clearWifiNetworks'
+			];
+			for (const func of wifiDeviceInterface) {
+				expect(result[func]).to.be.a('Function', `${platformName} implements ${func}`);
+			}
+		});
+	}
+});

--- a/src/wifi-device.test.js
+++ b/src/wifi-device.test.js
@@ -175,6 +175,33 @@ describe('WifiDevice', () => {
 				);
 				expect(wifiDevice._sendAndHandleProtobufRequest.firstCall.args[2]).to.eql(undefined);
 			});
+
+			// sc-96826: Once sc-TODO is fixed, this test should start working with some mods
+			xit('Can Join open Wifi network without security/password', async () => {
+				const fakeReply = {
+					pass: true,
+					replyObject: {
+						constructor: {
+							name: 'JoinNewNetworkReply'
+						}
+					}
+				};
+				sinon.stub(wifiDevice, '_sendAndHandleProtobufRequest').resolves(fakeReply);
+
+				const result = await wifiDevice.joinNewWifiNetwork({ ssid, password: null });
+				expect(result).to.eql(fakeReply);
+				expect(wifiDevice._sendAndHandleProtobufRequest).to.have.property('callCount', 1);
+				expect(wifiDevice._sendAndHandleProtobufRequest.firstCall.args).to.have.lengthOf(3);
+				expect(wifiDevice._sendAndHandleProtobufRequest.firstCall.args[0]).to.eql('wifi.JoinNewNetworkRequest');
+				expect(wifiDevice._sendAndHandleProtobufRequest.firstCall.args[1]).to.eql(
+					{
+						ssid,
+						bssid: null,
+						security: 0
+					}
+				);
+				expect(wifiDevice._sendAndHandleProtobufRequest.firstCall.args[2]).to.eql(undefined);
+			});
 		});
 
 		describe('clearWifiNetworks()', () => {

--- a/src/wifi-device.test.js
+++ b/src/wifi-device.test.js
@@ -1,32 +1,183 @@
 const { sinon, expect } = require('../test/support');
 const { setDevicePrototype } = require('./set-device-prototype');
 const { PLATFORMS } = require('./platforms');
+const { TimeoutError } = require('./error');
 
 describe('WifiDevice', () => {
-	const relevantPlatformNames = PLATFORMS
-		.filter(x => x.generation >= 3 && x.features.includes('wifi'))
-		.map(x => x.name);
-
-	beforeEach(() => {
-
-	});
-
 	afterEach(() => {
 		sinon.restore();
 	});
 
-	for (const platformName of relevantPlatformNames) {
-		it(`provides expected interface for platform=${platformName}`, async () => {
-			const fakeDevice = { type: platformName };
-			const result = setDevicePrototype(fakeDevice);
-			const wifiDeviceInterface = [
-				'scanWifiNetworks',
-				'joinNewWifiNetwork',
-				'clearWifiNetworks'
-			];
+	describe('expected interface for gen3+ wifi devices', () => {
+		const relevantPlatformNames = PLATFORMS
+			.filter(x => x.generation >= 3 && x.features.includes('wifi'))
+			.map(x => x.name);
+
+		const wifiDeviceInterface = [
+			'scanWifiNetworks',
+			'joinNewWifiNetwork',
+			'clearWifiNetworks'
+		];
+
+		for (const platformName of relevantPlatformNames) {
 			for (const func of wifiDeviceInterface) {
-				expect(result[func]).to.be.a('Function', `${platformName} implements ${func}`);
+				it(`includes ${func} Function for ${platformName} platform`, () => {
+					const fakeDevice = { type: platformName };
+					const result = setDevicePrototype(fakeDevice);
+					expect(result[func]).to.be.a('Function');
+				});
 			}
+		}
+	});
+
+	describe('behaviors', () => {
+		const fakeUSBDevice = { type: 'p2' };
+		let wifiDevice;
+
+		// this is a hidden network associated with a
+		// TP-Link N300 Wireless Portable Nano Travel Router
+		// note it does not have an ssid
+		const fakeNetworkWithoutSSID = {
+			'bssid': 'c0c9e376992f',
+			'security': 3,
+			'channel': 1,
+			'rssi': -20
+		};
+
+		// This is the actual 2.4 GHz network in Joe's House
+		const fakeValidNetwork1 = {
+			'ssid': 'how24ghz',
+			'bssid': '382c4a6a9040',
+			'security': 3,
+			'channel': 1,
+			'rssi': -58
+		};
+
+		// This is the actual 5 GHz network in Joe's House
+		const fakeValidNetwork2 = {
+			'ssid': 'how5ghz',
+			'bssid': '382c4a6a9044',
+			'security': 3,
+			'channel': 157,
+			'rssi': -66
+		};
+
+		// Note; no security field set for Comcast's WiFI
+		const fakeNetworkWithoutSecurity = {
+			'ssid': 'xfinitywifi',
+			'bssid': '1e9ecc0bed24',
+			'channel': 157,
+			'rssi': -88
+		};
+
+		const fakeScanNetworksReply = {
+			networks: [
+				fakeValidNetwork1,
+				fakeValidNetwork2,
+				fakeNetworkWithoutSSID,
+				fakeNetworkWithoutSecurity
+			]
+		};
+
+		beforeEach(async () => {
+			wifiDevice = setDevicePrototype(fakeUSBDevice);
 		});
-	}
+
+		afterEach(() => {
+			sinon.restore();
+		});
+
+		describe('scanWifiNetworks()', () => {
+			it('returns empty when no networks are returned', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').resolves({ networks: [] });
+				const result = await wifiDevice.scanWifiNetworks();
+				expect(result).to.eql([]);
+			});
+
+			it('returns valid networks with strings for security fields rather than integers', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').resolves(fakeScanNetworksReply);
+				const networks = await wifiDevice.scanWifiNetworks();
+				expect(networks).to.have.lengthOf(fakeScanNetworksReply.networks.length);
+				const firstNetwork = networks[0];
+				expect(firstNetwork.security).to.eql('WPA2_PSK');
+			});
+
+			it('converts security integer values to meaningful values based on existing protobuf enum', async () => {
+				expect(wifiDevice._mapSecurityValueToString(undefined)).to.eql('UNKNOWN');
+				expect(wifiDevice._mapSecurityValueToString(0)).to.eql('NO_SECURITY');
+				expect(wifiDevice._mapSecurityValueToString(1)).to.eql('WEP');
+				expect(wifiDevice._mapSecurityValueToString(2)).to.eql('WPA_PSK');
+				expect(wifiDevice._mapSecurityValueToString(3)).to.eql('WPA2_PSK');
+				expect(wifiDevice._mapSecurityValueToString(4)).to.eql('WPA_WPA2_PSK');
+				expect(wifiDevice._mapSecurityValueToString(444)).to.eql('UNKNOWN');
+			});
+
+			it('sets ssid to null if Device OS returns with undefined', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').resolves(fakeScanNetworksReply);
+				const networks = await wifiDevice.scanWifiNetworks();
+				expect(networks[2].bssid).to.eql(fakeNetworkWithoutSSID.bssid, 'targeting correct fixture');
+				expect(fakeNetworkWithoutSSID).to.not.have.haveOwnProperty('ssid');
+				expect(networks[2].ssid).to.eql(null);
+			});
+		});
+
+		describe('joinNewWifiNetwork()', () => {
+			let ssid, password;
+			beforeEach(() => {
+				ssid = 'ssid';
+				password = 'password';
+			});
+
+			it('Connects to network with valid SSID and password', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').resolves({
+					constructor: {
+						name: 'JoinNewNetworkReply'
+					}
+				});
+				const result = await wifiDevice.joinNewWifiNetwork({
+					ssid, password
+				});
+				expect(result).to.be.an('object');
+				expect(result.pass).to.eql(true);
+			});
+
+			it('Does not connect to network when sendProtobufRequest returns undefined', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').resolves(undefined); // This is one way that Device OS can reply
+				const result = await wifiDevice.joinNewWifiNetwork({
+					ssid, password
+				});
+				expect(result).to.be.an('object');
+				expect(result.pass).to.eql(false);
+				expect(result.error).to.eql('Device did not return a valid reply. expected=JoinNewNetworkReply actual=undefined');
+			});
+
+			it('Does not connect to network when sendProtobufRequest throws TimeourError', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').throws(new TimeoutError());
+				const result = await wifiDevice.joinNewWifiNetwork({
+					ssid, password
+				});
+				expect(result).to.be.an('object');
+				expect(result.pass).to.eql(false);
+				expect(result.error).to.eql('Request timed out, exceeded 20000ms');
+			});
+
+			it('Throws errors other than TimeoutError', async () => {
+				sinon.stub(wifiDevice, 'sendProtobufRequest').throws(new Error('hihihi'));
+
+				let error;
+				try {
+					await wifiDevice.joinNewWifiNetwork({
+						ssid, password
+					});
+				} catch (e) {
+					error = e;
+				}
+				expect(error.message).to.eql('hihihi');
+			});
+		});
+
+		describe('clearWifiNetworks()', () => {
+			it('TODO (jgoggins): continue here');
+		});
+	});
 });


### PR DESCRIPTION
## Overview

Executes the technical game-plan Julien, Mirande, Sergey, and Joe aligned on in this PR https://github.com/particle-iot/particle-usb/pull/57 (which will be closed in favor of the approach here).

Key outcomes from this PR:

1. `setDevicePrototype` which determines inheritance hierarchy for a given hardware device now has unit tests
2. `WifiDeviceLegacy` is used for gen1 (core) and gen2 (photon, p1) devices, `WifiDevice` is used for argon and P2.
3. Introduced `src/*.test.js` for each major sub-class to validate they provide expected interface.

There are some known limitations/questions I encountered while implementing this:

1. I think the way Mocha tests make assertions against mixin's is by asserting function definitions will work. In ruby-land, I'm used to the idea of asserting that a given instance has has a mixin included (i.e. `foo.include?(Mixin)`, but I don't think this is possible with ES6 classes.
2. I wanted to move `test/device.js` into `src/**/*.test.js` file, but it's mocking approach is way too different than the one I've been using. `fakeUSB` and `proxyquire` usage seems odd to me, feels like we're mocking out way to much and that we'd be better off doing this with vanilla Sinon instead; I deliberately didn't tackle this question/refactor because it's a big can o worms
3. I considered moving  `_sendAndHandleProtobufRequest` into `device.js` so ANY child class could use it rather than it only being used as the backend of these 3 new wifi methods. But wanted to discuss this before diving into it. I think this method could be the replacement for the private `sendRequest` and this work could happen while seeking to eliminate the technical debt in particle-usb before device-os-protobuf existed. Hoping to explore this in depth with Sergey and enqueue a chore story to do this later for a future release.
4. I tried to get passwordless wifi network joining to work, but couldn't, created a bug since it doesn't block P2 PVT, see [sc-96826](https://app.shortcut.com/particle/story/96826/particle-usb-joinnewwifinetwork-does-not-work-with-open-wifi-networks-without-security-password-on-p2-and-argon)

See [sc-96740](https://app.shortcut.com/particle/story/96740), for more details.

## How to test

1. Observe new Mocha tests that validate WifiDeviceLegacy interface, WifiDevice interfaces, and others
2. Run `npm run coverage`; observe ~95% Mocha test coverage over `WifiDevice`; missing 5% is because there is a bug in so we don't exercise it; [sc-96826](https://app.shortcut.com/particle/story/96826/particle-usb-joinnewwifinetwork-does-not-work-with-open-wifi-networks-without-security-password-on-p2-and-argon)
3. Validate functionality on real devices by running demo's on Argon or P2 in listening mode.

### scan-demo.js

```js
const particleUSB = require('./src/particle-usb');
async function main() {
	const devices = await particleUSB.getDevices();
	const device = devices[0];
	await device.open();
	const reply = await device.scanWifiNetworks();
	console.log(reply);
	await device.close();
}

main();
```

### join-demo.js

```js
const particleUSB = require('./src/particle-usb');
async function main() {
	const devices = await particleUSB.getDevices();
	const device = devices[0];
	await device.open();
	const reply = await device.joinNewWifiNetwork({
		ssid: '__TODO__PUT_SSID_HERE__',
		password: ''__TODO__PUT_PASSWORD_HERE__'
	});
	console.log(reply);
	await device.close();
}

main();
```

- After this, tap reset button, observe device connect to cloud via new network.



### clear-demo.js

```js
const particleUSB = require('./src/particle-usb');
async function main() {
	const devices = await particleUSB.getDevices();
	const device = devices[0];
	await device.open();
	const reply = await device.clearWifiNetworks();
	console.log(reply);
	await device.close();
}

main();
```

- After this, tap reset button, observe the device NOT connect to cloud and be in listening mode.

