### PR TITLE
Open Native USB Feature

### DIFF
--- a/src/device-base.js
+++ b/src/device-base.js
@@ -1,4 +1,4 @@
-const { getUsbDevices, MAX_CONTROL_TRANSFER_DATA_SIZE } = require('./usb-device-node');
+const { getUsbDevices, UsbDevice, MAX_CONTROL_TRANSFER_DATA_SIZE } = require('./usb-device-node');
 const proto = require('./usb-protocol');
 const { PLATFORMS } = require('./platforms');
 const { DeviceError, NotFoundError, StateError, TimeoutError, MemoryError, ProtocolError, assert } = require('./error');
@@ -774,9 +774,26 @@ async function openDeviceById(id, options = null) {
 	return dev;
 }
 
+async function openNativeUsbDevice(nativeUsbDevice, options = null) {
+	console.log('openNativeUsbDevice nativeUsbDevice', nativeUsbDevice);
+
+	const usbDevice = new UsbDevice(nativeUsbDevice);
+	console.log('openNativeUsbDevice usbDevice', usbDevice);
+
+	const platform = platformForUsbIds(usbDevice.vendorId, usbDevice.productId);
+	assert(platform);
+	console.log('openNativeUsbDevice platform', platform);
+	const dev = new DeviceBase(usbDevice, platform);
+	console.log('openNativeUsbDevice dev', dev);
+	await dev.open(options);
+	console.log('open complete isOpen=' + dev.isOpen);
+	return dev;
+}
+
 module.exports = {
 	PollingPolicy,
 	DeviceBase,
 	getDevices,
-	openDeviceById
+	openDeviceById,
+	openNativeUsbDevice
 };

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -775,18 +775,15 @@ async function openDeviceById(id, options = null) {
 }
 
 async function openNativeUsbDevice(nativeUsbDevice, options = null) {
-	console.log('openNativeUsbDevice nativeUsbDevice', nativeUsbDevice);
 
 	const usbDevice = new UsbDevice(nativeUsbDevice);
-	console.log('openNativeUsbDevice usbDevice', usbDevice);
 
 	const platform = platformForUsbIds(usbDevice.vendorId, usbDevice.productId);
 	assert(platform);
-	console.log('openNativeUsbDevice platform', platform);
 	const dev = new DeviceBase(usbDevice, platform);
-	console.log('openNativeUsbDevice dev', dev);
+
 	await dev.open(options);
-	console.log('open complete isOpen=' + dev.isOpen);
+
 	return dev;
 }
 

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -779,7 +779,9 @@ async function openNativeUsbDevice(nativeUsbDevice, options = null) {
 	const usbDevice = new UsbDevice(nativeUsbDevice);
 
 	const platform = platformForUsbIds(usbDevice.vendorId, usbDevice.productId);
-	assert(platform);
+	if (!platform) {
+		throw new NotFoundError('Unsupported device type');
+	}
 	const dev = new DeviceBase(usbDevice, platform);
 
 	await dev.open(options);

--- a/src/device-base.test.js
+++ b/src/device-base.test.js
@@ -1,7 +1,7 @@
 const { fakeUsb, sinon, expect, assert, nextTick } = require('../test/support');
 const proxyquire = require('proxyquire');
 
-const { getDevices, openDeviceById, PollingPolicy } = proxyquire('../src/device-base', {
+const { getDevices, openDeviceById, openNativeUsbDevice, PollingPolicy } = proxyquire('../src/device-base', {
 	'./usb-device-node': fakeUsb
 });
 const usbImpl = require('./usb-device-node');
@@ -193,6 +193,29 @@ describe('device-base', () => {
 			await openDeviceById('abcdabcdabcdabcdabcdabcd');
 			await openDeviceById('CDEFCDEFCDEFCDEFCDEFCDEF');
 		});
+	});
+
+	describe('openNativeUsbDevice()', () => {
+		it('opens a native usb device', async () => {
+			const fakeNativeDevice = {
+				open: function() {
+				},
+				close: function() {
+				},
+				deviceDescriptor: {
+					iSerialNumber: '111111111111111111111111',
+					idVendor: 0x2b04,
+					idProduct: 0xc00a,
+				},
+				getStringDescriptor: function(s, fn) {
+					fn(null, s);
+				}
+			};
+			const dev = await openNativeUsbDevice(fakeNativeDevice);
+			expect(dev.isOpen).to.be.true;
+			expect(dev.id).to.equal('111111111111111111111111');
+		});
+
 	});
 
 	describe('DeviceBase', () => {

--- a/src/device-base.test.js
+++ b/src/device-base.test.js
@@ -216,6 +216,24 @@ describe('device-base', () => {
 			expect(dev.id).to.equal('111111111111111111111111');
 		});
 
+		it('opens throws an exception on invalid device', async () => {
+			const fakeNativeDevice = {
+				open: function() {
+				},
+				close: function() {
+				},
+				deviceDescriptor: {
+					iSerialNumber: '111111111111111111111111',
+					idVendor: 0x2b04,
+					idProduct: 0xcfff,
+				},
+				getStringDescriptor: function(s, fn) {
+					fn(null, s);
+				}
+			};
+			const dev = openNativeUsbDevice(fakeNativeDevice);
+			await expect(dev).to.be.rejectedWith(error.NotFoundError);
+		});
 	});
 
 	describe('DeviceBase', () => {

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -1,4 +1,4 @@
-const { getDevices: getUsbDevices, openDeviceById: openUsbDeviceById } = require('./device-base');
+const { getDevices: getUsbDevices, openDeviceById: openUsbDeviceById, openNativeUsbDevice: openUsbNativeUsbDevice } = require('./device-base');
 const { PollingPolicy } = require('./device-base');
 const { FirmwareModule } = require('./device');
 const { NetworkStatus } = require('./network-device');
@@ -33,6 +33,17 @@ function openDeviceById(id, options) {
 	return openUsbDeviceById(id, options).then(dev => setDevicePrototype(dev));
 }
 
+/**
+ * Open a Particle USB device from a native browser or node USB device handle
+ *
+ * @param {Object} nativeUsbDevice A WebUSB (browser) or node-usb USB device
+ * @param {Object} [options] Options (see {@link DeviceBase#open}).
+ * @return {Promise<Device>}
+ */
+function openNativeUsbDevice(nativeUsbDevice, options) {
+	return openUsbNativeUsbDevice(nativeUsbDevice, options).then(dev => setDevicePrototype(dev));
+}
+
 module.exports = {
 	PollingPolicy,
 	FirmwareModule,
@@ -56,5 +67,6 @@ module.exports = {
 	RequestError,
 	getDevices,
 	openDeviceById,
+	openNativeUsbDevice,
 	config
 };

--- a/src/particle-usb.test.js
+++ b/src/particle-usb.test.js
@@ -4,6 +4,7 @@ describe('Public interface of npm module', () => {
 	it('exports expected objects and functions', () => {
 		expect(particleUSB.getDevices).to.be.a('Function');
 		expect(particleUSB.openDeviceById).to.be.a('Function');
+		expect(particleUSB.openNativeUsbDevice).to.be.a('Function');
 		expect(particleUSB.PollingPolicy).to.be.an('object');
 		expect(particleUSB.PollingPolicy.DEFAULT).to.be.a('Function');
 

--- a/test/e2e/__fixtures__/web-proj/index.html
+++ b/test/e2e/__fixtures__/web-proj/index.html
@@ -13,6 +13,7 @@
 	<div id="main">
 		<button id="btn-selectdevice">Select Device</button>
 		<button id="btn-reset">Reset</button>
+		<button id="btn-native-listen">Native Listening Mode</button>
 		<ul id="device-list"></ul>
 	</div>
 	<script>
@@ -38,6 +39,36 @@
 			const deviceList = document.getElementById('device-list');
 			deviceList.innerHTML = '';
 		});
+
+		const nativeListenBtn = document.getElementById('btn-native-listen');
+		nativeListenBtn.addEventListener('click', async (even) => {
+			let filters = [
+				{vendorId: 0x2b04}
+			];
+            const nativeUsbDevice = await navigator.usb.requestDevice({ filters: filters })
+			if (nativeUsbDevice) {
+				const deviceList = document.getElementById('device-list');
+				const li = document.createElement('li');
+
+				try {
+					const device = await ParticleUsb.openNativeUsbDevice(nativeUsbDevice, {});
+					li.id = 'test-device-ok';
+					li.innerText = `opened: ${device.id} | ${device.type}`;
+					window.__PRTCL_DEVICE_ID__ = device.id;
+
+					await device.enterListeningMode();
+					window.__PRTCL_DEVICE_MODE__ = await device.getDeviceMode();
+
+					await device.close();
+				} catch (error){
+					console.log('error', error);
+					li.id = 'test-device-error';
+					li.innerText = 'failed to open device';
+				}
+
+				deviceList.appendChild(li);
+			}
+		})
 	</script>
 </body>
 

--- a/test/e2e/__fixtures__/web-proj/index.html
+++ b/test/e2e/__fixtures__/web-proj/index.html
@@ -13,7 +13,6 @@
 	<div id="main">
 		<button id="btn-selectdevice">Select Device</button>
 		<button id="btn-reset">Reset</button>
-		<button id="btn-native-listen">Native Listening Mode</button>
 		<ul id="device-list"></ul>
 	</div>
 	<script>
@@ -39,36 +38,6 @@
 			const deviceList = document.getElementById('device-list');
 			deviceList.innerHTML = '';
 		});
-
-		const nativeListenBtn = document.getElementById('btn-native-listen');
-		nativeListenBtn.addEventListener('click', async (even) => {
-			let filters = [
-				{vendorId: 0x2b04}
-			];
-            const nativeUsbDevice = await navigator.usb.requestDevice({ filters: filters })
-			if (nativeUsbDevice) {
-				const deviceList = document.getElementById('device-list');
-				const li = document.createElement('li');
-
-				try {
-					const device = await ParticleUsb.openNativeUsbDevice(nativeUsbDevice, {});
-					li.id = 'test-device-ok';
-					li.innerText = `opened: ${device.id} | ${device.type}`;
-					window.__PRTCL_DEVICE_ID__ = device.id;
-
-					await device.enterListeningMode();
-					window.__PRTCL_DEVICE_MODE__ = await device.getDeviceMode();
-
-					await device.close();
-				} catch (error){
-					console.log('error', error);
-					li.id = 'test-device-error';
-					li.innerText = 'failed to open device';
-				}
-
-				deviceList.appendChild(li);
-			}
-		})
 	</script>
 </body>
 

--- a/test/e2e/browser.e2e.js
+++ b/test/e2e/browser.e2e.js
@@ -137,38 +137,38 @@ describe('Browser Usage', () => {
 
 		afterEach(async () => {
 			await page.click(selectors.reset);
-			
+
 			await page.evaluate(async (id) => {
 				const webDevice = await ParticleUsb.openDeviceById(id);
 				await webDevice.reset();
 			}, deviceId);
-			
+
 		});
 
 		it('Enters listening mode', async () => {
 			await page.click(selectors.nativeListenButton);
-			
+
 			let result;
 
-			for(let tries = 1; tries < 20; tries++) {
+			for (let tries = 1; tries < 20; tries++) {
 				result = await page.evaluate(async () => {
-					return {deviceId: window.__PRTCL_DEVICE_ID__, deviceMode:window.__PRTCL_DEVICE_MODE__};
+					return { deviceId: window.__PRTCL_DEVICE_ID__, deviceMode:window.__PRTCL_DEVICE_MODE__ };
 				});
 				if (result.deviceId) {
 					break;
 				}
-	
+
 				await new Promise(function(resolve) {
-                    setTimeout(function() {
-                        resolve();
-                    }, 1000);
-                });    
+					setTimeout(function() {
+						resolve();
+					}, 1000);
+				});
 			}
 			deviceId = result.deviceId;
 			console.log('opened ' + deviceId);
 
 			expect(result.deviceMode).to.equal('LISTENING');
-			
+
 		});
 	});
 

--- a/test/e2e/browser.e2e.js
+++ b/test/e2e/browser.e2e.js
@@ -18,7 +18,6 @@ describe('Browser Usage', () => {
 		ok: '#test-device-ok',
 		error: '#test-device-error',
 		selectDevice: '#btn-selectdevice',
-		nativeListenButton: '#btn-native-listen',
 		reset: '#btn-reset'
 	};
 
@@ -101,6 +100,7 @@ describe('Browser Usage', () => {
 			await page.evaluate(async (id) => {
 				const webDevice = await ParticleUsb.openDeviceById(id);
 				await webDevice.reset();
+				await webDevice.close();
 			}, deviceId);
 		});
 
@@ -109,6 +109,25 @@ describe('Browser Usage', () => {
 				const webDevices = await ParticleUsb.getDevices();
 				const webDevice = webDevices[0];
 				await webDevice.open();
+				await webDevice.enterListeningMode();
+				return await webDevice.getDeviceMode();
+			});
+
+			expect(mode).to.equal('LISTENING');
+		});
+
+		it('Enters listening mode using a native webusb device reference', async () => {
+			const mode = await page.evaluate(async () => {
+				const filters = [
+					{ vendorId: 0x2b04 }
+				];
+
+				const nativeUsbDevice = await navigator.usb.requestDevice({
+					filters
+				});
+
+				const webDevice = await ParticleUsb.openNativeUsbDevice(nativeUsbDevice);
+
 				await webDevice.enterListeningMode();
 				return await webDevice.getDeviceMode();
 			});
@@ -126,51 +145,6 @@ describe('Browser Usage', () => {
 		await page.evaluate((id) => window.__PRTCL_DEVICE_ID__ = id, deviceId);
 		return { deviceId, device, devices };
 	}
-
-	// This is disabled by default because you need to manually select and authorize the device
-	// to use WebUSB
-	describe.skip('Changing Device Modes openNativeUsbDevice [@device]', () => {
-		let deviceId;
-
-		before(async () => {
-		});
-
-		afterEach(async () => {
-			await page.click(selectors.reset);
-
-			await page.evaluate(async (id) => {
-				const webDevice = await ParticleUsb.openDeviceById(id);
-				await webDevice.reset();
-			}, deviceId);
-
-		});
-
-		it('Enters listening mode', async () => {
-			await page.click(selectors.nativeListenButton);
-
-			let result;
-
-			for (let tries = 1; tries < 20; tries++) {
-				result = await page.evaluate(async () => {
-					return { deviceId: window.__PRTCL_DEVICE_ID__, deviceMode:window.__PRTCL_DEVICE_MODE__ };
-				});
-				if (result.deviceId) {
-					break;
-				}
-
-				await new Promise(function(resolve) {
-					setTimeout(function() {
-						resolve();
-					}, 1000);
-				});
-			}
-			deviceId = result.deviceId;
-			console.log('opened ' + deviceId);
-
-			expect(result.deviceMode).to.equal('LISTENING');
-
-		});
-	});
 
 	function createServer(assets){
 		return http.createServer((req, res) => {

--- a/test/e2e/node.e2e.js
+++ b/test/e2e/node.e2e.js
@@ -71,13 +71,14 @@ describe('Node.js Usage', () => {
 	});
 
 	describe('Basic Device Interactions [@device]', () => {
-		let device, devices;
+		let device, devices, deviceId;
 
 		beforeEach(async () => {
 			const usb = require(PROJ_NODE_DIR);
 			devices = await usb.getDevices();
 			device = devices[0];
 			await device.open();
+			deviceId = device.id;
 		});
 
 		afterEach(async () => {
@@ -94,6 +95,14 @@ describe('Node.js Usage', () => {
 				'CONNECTING',
 				'CONNECTED'
 			]);
+		});
+
+		it('Opens device using a native usb device reference', async () => {
+			const { openNativeUsbDevice } = require(PROJ_NODE_DIR);
+			await device.close();
+			const nativeUsbDevice = device._dev._dev; // using `device._dev._dev` instead causes the test to pass
+			device = await openNativeUsbDevice(nativeUsbDevice);
+			expect(deviceId).to.equal(device.id);
 		});
 	});
 });

--- a/test/e2e/node.e2e.js
+++ b/test/e2e/node.e2e.js
@@ -100,7 +100,7 @@ describe('Node.js Usage', () => {
 		it('Opens device using a native usb device reference', async () => {
 			const { openNativeUsbDevice } = require(PROJ_NODE_DIR);
 			await device.close();
-			const nativeUsbDevice = device._dev._dev; // using `device._dev._dev` instead causes the test to pass
+			const nativeUsbDevice = device._dev._dev;
 			device = await openNativeUsbDevice(nativeUsbDevice);
 			expect(deviceId).to.equal(device.id);
 		});

--- a/test/integration/device-base.js
+++ b/test/integration/device-base.js
@@ -1,4 +1,4 @@
-const { getDevices, openDeviceById } = require('../../src/particle-usb');
+const { getDevices, openDeviceById, openNativeUsbDevice } = require('../../src/particle-usb');
 const { MAX_CONTROL_TRANSFER_DATA_SIZE } = require('../../src/usb-device-node');
 
 const { expect, randomString, integrationTest } = require('../support');
@@ -79,4 +79,27 @@ describe('device-base', function desc() {
 			});
 		});
 	});
+
+
+	describe('openNativeUsbDevice()', () => {
+		it('it can open a native USB device handle', async () => {
+			if (devs.length < 1) {
+				throw new Error('This test requires a device');
+			}
+			const dev1 = devs[0];
+			dev1.open();
+			const id1 = dev1.id;
+			dev1.close();
+
+			const nativeUsbDevice = dev1._dev;
+
+			const dev2 = openNativeUsbDevice(nativeUsbDevice);
+			dev2.open();
+			const id2 = dev2.id;
+			dev2.close();
+
+			expect(id1).to.equal(id2);
+		});
+	});
+
 });

--- a/test/integration/device-base.js
+++ b/test/integration/device-base.js
@@ -87,17 +87,13 @@ describe('device-base', function desc() {
 				throw new Error('This test requires a device');
 			}
 			const dev1 = devs[0];
-			dev1.open();
+			await dev1.open();
 			const id1 = dev1.id;
-			dev1.close();
-
-			const nativeUsbDevice = dev1._dev;
-
-			const dev2 = openNativeUsbDevice(nativeUsbDevice);
-			dev2.open();
+			await dev1.close();
+			const nativeUsbDevice = dev1.usbDevice.internalObject;
+			const dev2 = await openNativeUsbDevice(nativeUsbDevice);
 			const id2 = dev2.id;
-			dev2.close();
-
+			await dev2.close();
 			expect(id1).to.equal(id2);
 		});
 	});


### PR DESCRIPTION
The docs currently use a branch of particle-usb with a few custom modifications. The plan is to roll the changes back into the mainline, fixing the API, adding tests, etc.

## The new changes

There are two changes:

- In enterDfuMode, add a noReconnectWait option. This is desirable in a WebUSB environment because if the device was first use when already in DFU mode, when exiting DFU mode, the browser may request authorization to the non-DFU interface, since the browser must separately authorize each. This leads to an awkward user experience when the user doesn’t need to manipulate the device.
- Added a new method openNativeUsbDevice, which works like openByDeviceID, except it takes a native WebUSB device object. This is useful when you want to customize the device selection for WebUSB, and other cases where you already have the native WebUSB object but want to wrap it in particle-usb.

## Tests

I also added test cases for the new code. There are unit tests in device-base-test.js that are run automatically during the test:ci phase. There is also an e2e test in browser.e2e.js that is not automatically run because it requires interacting with WebUSB authorization in a browser. 

