### PR TITLE
feature/sc-111593/get-device-info

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -24,11 +24,25 @@ const FirmwareModule = fromProtobufEnum(DeviceOSProtobuf.definitions.FirmwareMod
 	USER_PART: 'USER_PART',
 	/** Monolithic firmware module. */
 	MONO_FIRMWARE: 'MONO_FIRMWARE',
-	/** NCP_FIRMWARE */
+	/** Network co-processor firmware module */
 	NCP_FIRMWARE: 'NCP_FIRMWARE',
-	/** RADIO_STACK */
+	/** Radio stack module */
 	RADIO_STACK: 'RADIO_STACK'
 });
+
+/**
+ * Firmware module readable names
+ *
+ * @enum {String}
+ */
+const FirmwareModuleDisplayNames = {
+	[FirmwareModule.BOOTLOADER]: 'Bootloader',
+	[FirmwareModule.SYSTEM_PART]: 'System Part',
+	[FirmwareModule.USER_PART]: 'User Part',
+	[FirmwareModule.MONO_FIRMWARE]: 'Monolithic Firmware',
+	[FirmwareModule.NCP_FIRMWARE]: 'Network Co-processor Firmware',
+	[FirmwareModule.RADIO_STACK]: 'Radio Stack Module'
+};
 
 /**
  * Device modes.
@@ -916,6 +930,7 @@ class Device extends DeviceBase {
 
 module.exports = {
 	FirmwareModule,
+	FirmwareModuleDisplayNames,
 	DeviceMode,
 	LogLevel,
 	Device

--- a/src/device.js
+++ b/src/device.js
@@ -15,7 +15,7 @@ const DeviceOSProtobuf = require('@particle/device-os-protobuf');
  *
  * @enum {String}
  */
-const FirmwareModule = fromProtobufEnum(proto.FirmwareModuleType, {
+const FirmwareModule = fromProtobufEnum(DeviceOSProtobuf.definitions.FirmwareModuleType, {
 	/** Bootloader module. */
 	BOOTLOADER: 'BOOTLOADER',
 	/** System part module. */
@@ -23,7 +23,11 @@ const FirmwareModule = fromProtobufEnum(proto.FirmwareModuleType, {
 	/** User part module. */
 	USER_PART: 'USER_PART',
 	/** Monolithic firmware module. */
-	MONO_FIRMWARE: 'MONO_FIRMWARE'
+	MONO_FIRMWARE: 'MONO_FIRMWARE',
+	/** NCP_FIRMWARE */
+	NCP_FIRMWARE: 'NCP_FIRMWARE',
+	/** RADIO_STACK */
+	RADIO_STACK: 'RADIO_STACK'
 });
 
 /**

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -1,6 +1,6 @@
 const { getDevices: getUsbDevices, openDeviceById: openUsbDeviceById, openNativeUsbDevice: openUsbNativeUsbDevice } = require('./device-base');
 const { PollingPolicy } = require('./device-base');
-const { FirmwareModule } = require('./device');
+const { FirmwareModule, FirmwareModuleDisplayNames } = require('./device');
 const { NetworkStatus } = require('./network-device');
 const { WifiAntenna, WifiSecurity, WifiCipher, EapMethod } = require('./wifi-device');
 const { CloudConnectionStatus, ServerProtocol } = require('./cloud-device');
@@ -47,6 +47,7 @@ function openNativeUsbDevice(nativeUsbDevice, options) {
 module.exports = {
 	PollingPolicy,
 	FirmwareModule,
+	FirmwareModuleDisplayNames,
 	NetworkStatus,
 	WifiAntenna,
 	WifiSecurity,


### PR DESCRIPTION
## Description

This PR will add a new method that will return the device's firmware Modules information in a "user-friendly" way.
Also it was updated the firmware module types registered in the `FirmwareModule` object to align that with the current `protobuf` constants.
 
New method: `getFirmwareModuleInfo()`

## How to test
1. Pull down this branch: `git pull && git checkout feature/sc-111593/get-device-info`
2. Install all dependencies: `npm run reinstall` ( or `npm i` if it's your first time see instructions [here](https://github.com/particle-iot/particle-usb#installing))
3. fire up the Node.js REPL:
    * `cd particle-usb`
    * `node`
4. connect a device to your USB
5. load, init a device:
```js
const usb = require('.');

(async () => {
  
	const devices = await usb.getDevices();
	const device = devices[0];
	await device.open();
	const info = await device.getFirmwareModuleInfo();
	console.log(info);
	await device.close();

})();

```

### outcome
All tests should pass, npm's `package-lock.json` file should not show changes after reinstalling.
It will print the firmware modules related with the device you're connected.
e.g.  output:


```js
[
  {
    type: 'BOOTLOADER',
    index: 0,
    version: 2001,
    size: 52568,
    dependencies: [ [Object] ]
  },
  {
    type: 'BOOTLOADER',
    index: 1,
    version: 2,
    size: 3996,
    dependencies: []
  },
  {
    type: 'BOOTLOADER',
    index: 2,
    version: 3,
    size: 19592,
    dependencies: []
  },
  {
    type: 'SYSTEM_PART',
    index: 1,
    version: 5003,
    size: 971242,
    dependencies: [ [Object] ]
  },
  {
    type: 'USER_PART',
    index: 1,
    version: 6,
    size: 28668,
    dependencies: [ [Object] ]
  }
]
```  


## Related / Discussions
https://app.shortcut.com/particle/story/111593

update `firmareModulesType` constants
https://app.shortcut.com/particle/story/111351

## Completeness

- [x] PR opened :tada:
- [x] Testing instructions have been provided
- [x] Tracking story is up to date (tasks are marked complete, state is "ready for review")
- [x] Changes adhere to repo conventions
- [x] Development How-To's have been provided
- [x] Docs have been updated (`npm run docs`)
- [x] Branch is rebased against _target_ (typically `main`)
