### PR TITLE
chore/SC-116732/add-Orson-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@particle/async-utils": "^4.0.2",
-        "@particle/device-constants": "^3.0.0",
+        "@particle/device-constants": "^3.1.6",
         "buffer": "^6.0.3",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -40,7 +40,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "^3.0.0"
+        "@particle/device-constants": "^3.1.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2315,9 +2315,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.0.tgz",
-      "integrity": "sha512-vcPcVvg4NxtnOmjwzHGsVpGjlUXrvGEwF0WHp2HbzIR5m0Lqfr2isNHy+q/gbNk4m/jIgtPoK1K6SCA4TnIOKQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
+      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -13321,9 +13321,9 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.0.tgz",
-      "integrity": "sha512-vcPcVvg4NxtnOmjwzHGsVpGjlUXrvGEwF0WHp2HbzIR5m0Lqfr2isNHy+q/gbNk4m/jIgtPoK1K6SCA4TnIOKQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
+      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g==",
       "dev": true
     },
     "@particle/device-os-protobuf": {

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "usb": "^2.5.0"
   },
   "peerDependencies": {
-    "@particle/device-constants": "^3.0.0"
+    "@particle/device-constants": "^3.1.6"
   },
   "devDependencies": {
     "@particle/async-utils": "^4.0.2",
-    "@particle/device-constants": "^3.0.0",
+    "@particle/device-constants": "^3.1.6",
     "buffer": "^6.0.3",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
### Description

Update `device-constants` dependency to support Orson

### How to test

1. Pull down this branch `git pull && git checkout chore/SC-116732/add-Orson-platform`
2. Reinstall dependencies `npm run reinstall`
3. Run tests npm test`

#### Outcome

Dependencies install successfully, lockfile shows no edits, and tests pass 👍