### PR TITLE
Add support for a progress callback

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -376,7 +376,7 @@ class Device extends DeviceBase {
 			}
 			const { chunkSize } = await s.sendRequest(Request.START_FIRMWARE_UPDATE, { size: data.length });
 			if (progress) {
-				progress({ event: 'complete-erase', bytes: data.length });
+				progress({ event: 'erased', bytes: data.length });
 				progress({ event: 'start-download', bytes: data.length });
 			}
 			let offs = 0;

--- a/src/device.js
+++ b/src/device.js
@@ -364,9 +364,10 @@ class Device extends DeviceBase {
 	 * @param {Buffer} data Firmware data.
 	 * @param {Object} [options] Options.
 	 * @param {Number} [options.timeout] Timeout (milliseconds).
+	 * @param {Function} [options.progress] User's callback function to log progress of the flashing process.
 	 * @return {Promise}
 	 */
-	async updateFirmware(data, { timeout = DEFAULT_FIRMWARE_UPDATE_TIMEOUT } = {}, progress) {
+	async updateFirmware(data, { timeout = DEFAULT_FIRMWARE_UPDATE_TIMEOUT, progress } = {}) {
 		if (!data.length) {
 			throw new RangeError('Invalid firmware size');
 		}

--- a/src/device.js
+++ b/src/device.js
@@ -366,19 +366,32 @@ class Device extends DeviceBase {
 	 * @param {Number} [options.timeout] Timeout (milliseconds).
 	 * @return {Promise}
 	 */
-	async updateFirmware(data, { timeout = DEFAULT_FIRMWARE_UPDATE_TIMEOUT } = {}) {
+	async updateFirmware(data, { timeout = DEFAULT_FIRMWARE_UPDATE_TIMEOUT } = {}, progress) {
 		if (!data.length) {
 			throw new RangeError('Invalid firmware size');
 		}
 		return this.timeout(timeout, async (s) => {
+			if (progress) {
+				progress({ event: 'start-erase', bytes: data.length });
+			}
 			const { chunkSize } = await s.sendRequest(Request.START_FIRMWARE_UPDATE, { size: data.length });
+			if (progress) {
+				progress({ event: 'complete-erase', bytes: data.length });
+				progress({ event: 'start-download', bytes: data.length });
+			}
 			let offs = 0;
 			while (offs < data.length) {
 				const n = Math.min(chunkSize, data.length - offs);
 				await s.sendRequest(Request.FIRMWARE_UPDATE_DATA, { data: data.slice(offs, offs + n) });
+				if (progress) {
+					progress({ event: 'downloaded', bytes: n });
+				}
 				offs += n;
 			}
 			await s.sendRequest(Request.FINISH_FIRMWARE_UPDATE, { validateOnly: false });
+			if (progress) {
+				progress({ event: 'complete-download', bytes: data.length });
+			}
 		});
 	}
 

--- a/src/dfu-device.js
+++ b/src/dfu-device.js
@@ -2,16 +2,18 @@ const DfuDevice = (base) => class extends base {
 	/**
 	 * Flashes the firmware over DFU interface.
 	 *
-	 * @param {Number} altSetting The interface alternate setting.
-	 * @param {Buffer} buffer The binary firmware data to be flashed.
-	 * @param {Number} addr The starting address where the firmware will be written.
-	 * @param {Function} progress User's callback function to log progress of the flashing process.
-	 * @param {Object} options Optional options for the flashing process (noErase, leave).
+	 * @param {Buffer} data The binary firmware data to be flashed.
+	 * @param {Object} options Options.
+	 * @param {Number} options.altSetting The interface alternate setting.
+	 * @param {Number} options.startAddr The starting address where the firmware will be written.
+	 * @param {boolean} [options.noErase] - Skip erasing the device memory.
+	 * @param {boolean} [options.leave] - Leave DFU mode after download.
+	 * @param {Function} [options.progress] User's callback function to log progress of the flashing process.
 	 * @returns {Promise<void>} A Promise that resolves when the firmware is successfully flashed.
 	 */
-	async writeOverDfu({ altSetting, buffer, addr, options, progress }) {
+	async writeOverDfu(data, { altSetting, startAddr, noErase, leave, progress }) {
 		await this._dfu.setAltSetting(altSetting);
-		await this._dfu.doDownload(addr, buffer, options, progress);
+		await this._dfu.doDownload({ startAddr, data, noErase, leave, progress });
 	}
 };
 

--- a/src/dfu-device.js
+++ b/src/dfu-device.js
@@ -5,12 +5,13 @@ const DfuDevice = (base) => class extends base {
 	 * @param {Number} altSetting The interface alternate setting.
 	 * @param {Buffer} buffer The binary firmware data to be flashed.
 	 * @param {Number} addr The starting address where the firmware will be written.
-	 * @param {Object} options Optional options for the flashing process.
+	 * @param {Function} progress User's callback function to log progress of the flashing process.
+	 * @param {Object} options Optional options for the flashing process (noErase, leave).
 	 * @returns {Promise<void>} A Promise that resolves when the firmware is successfully flashed.
 	 */
-	async writeOverDfu(altSetting, buffer, addr, options) {
+	async writeOverDfu({ altSetting, buffer, addr, options, progress }) {
 		await this._dfu.setAltSetting(altSetting);
-		await this._dfu.doDownload(addr, buffer, options);
+		await this._dfu.doDownload(addr, buffer, options, progress);
 	}
 };
 

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -249,7 +249,8 @@ class Dfu {
 	 *
 	 * @param {number} startAddr - The starting address to write the data.
 	 * @param {Buffer} data - The binary data to write.
-	 * @param {object} options - Options for the download process.
+	 * @param {object} options - Options for the download process. (noErase, leave)
+	 * @param {function} progress - Callback function used to log progress.
 	 * @return {Promise}
 	 */
 	async doDownload(startAddr, data, options = { noErase: false, leave: false }, progress) {

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -625,9 +625,6 @@ class Dfu {
 				progress({ event: 'erased', bytes: segment.sectorSize });
 			}
 		}
-		if (progress) {
-			progress({ event: 'complete-erase', bytes: bytesErased });
-		}
 	}
 
 	async _getStringDescriptor(index) {


### PR DESCRIPTION
### Description

This PR adds support for a progress callback that the user may use to log progress during the flashing process.

The following events have been added:
- `start-erase` (Starts erase)
     - More easily testable for dfu than for control requests
     - For control requests via `updateFirmware`, the erase functionality depends on flags which are set inside the device-os. I am still adding in without checking for those flags
- `erased`
    - Erase in progress and shows that `bytes` number of bytes are erased at that time
- `start-download`
    - Started download process
- `downloaded`
    - Download still in progress. Downloaded `bytes` number of bytes at that time
- `complete-download`
    - Completed download without any errors
- `failed-download`
    - Failed downloaded (Valid only for dfu. Unable to find this state in the updateFirmware function?)
    - For control requests, it appears that the error is caught by the caller

### Usage
1. Checkout this branch
2. Point the usb module of your test script to the folder path of this branch
```
const usb = require('/path/to/local/particle-usb');
const fs = require('fs-extra');
const { HalModuleParser } = require('binary-version-reader');

async function main() {
  const devices = await usb.getDevices();
  if (devices.length === 0) {
    throw new Error('No devices found');
  }
  const device = devices[0];
  console.log('Device : ', device);
  await device.open();
  await device.enterDfuMode();

  const buf = await fs.readFile('/path/to/binaries/5.4.0/p2/p2-system-part1@5.4.0.bin');
  const reader = new HalModuleParser();
  const parsed = await reader.parseBuffer({ fileBuffer: buf });
  const addr = parseInt(parsed.prefixInfo.moduleStartAddy, 16);
  await dev.writeOverDfu({
	altSetting: 0,
	buffer: parsed.fileBuffer,
	addr: addr,
	options: {},
	progress: this.progressCb
});

  const bufTinker = await fs.readFile('/path/to/binaries/5.4.0/p2/p2-tinker@5.4.0.bin');
  const parsedTinker = await reader.parseBuffer({ fileBuffer: bufTinker });
  const addrTinker = parseInt(parsedTinker.prefixInfo.moduleStartAddy, 16);
  await dev.writeOverDfu({
	altSetting: 0,
	buffer: parsedTinker.fileBuffer,
	addr: addrTinker,
	options: {},
	progress: this.progressCb
});

  await device.reset();
}

main().catch((error) => {
  console.error('Error:', error.message);
});
```

This is the progressCb function, for example
```
progressCb({event: event, bytes: bytes}) {
	console.log('Event: ' + event + ' Bytes: ' + bytes);
}

```

### Example from a P2 in DFU
```
Event: start-erase Bytes: 1011712    // Started erasing System-part1 over DFU
Event: erased Bytes: 4096
Event: erased Bytes: 4096
Event: erased Bytes: 4096
.
.
Event: erased Bytes: 4096
Event: erased Bytes: 4096
Event: start-download Bytes: 1009100     // Started downloading System-part1 over DFU
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 4096
.
.
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 1484
Event: complete-download Bytes: 1009100
Event: start-erase Bytes: 49152     // Started erasing Tinker over DFU
Event: erased Bytes: 4096
Event: erased Bytes: 4096
.
.
Event: erased Bytes: 4096
Event: erased Bytes: 4096
Event: start-download Bytes: 49152     // Started download Tinker over DFU
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 4096
.
.
Event: downloaded Bytes: 4096
Event: downloaded Bytes: 4096
Event: complete-download Bytes: 49152


```

### Example from a tracker over control requests
```
Calling update firmware on tracker-bootloader@4.1.0.bin
Event: start-erase Bytes: 46132
Event: erased Bytes: 46132
Event: start-download Bytes: 46132
Event: downloaded Bytes: 1024
Event: downloaded Bytes: 1024
.
.
Event: downloaded Bytes: 1024
Event: downloaded Bytes: 52
Event: complete-download Bytes: 46132


Calling update firmware on tracker-esp32-ncp@5.3.0.bin
Event: start-erase Bytes: 864464
Event: erased Bytes: 864464
Event: start-download Bytes: 864464
Event: downloaded Bytes: 1024
Event: downloaded Bytes: 1024
.
.
Event: downloaded Bytes: 1024
Event: downloaded Bytes: 208
Event: complete-download Bytes: 864464
! System firmware update successfully completed!

> Your device should now restart automatically.


Process finished with exit code 0
```