### PR TITLE
Prevent the underlying device instance from being closed multiple times

### DIFF
--- a/src/device-base.js
+++ b/src/device-base.js
@@ -380,6 +380,8 @@ class DeviceBase extends EventEmitter {
 		}
 		if (this._state === DeviceState.CLOSING && this._activeReqs === 0) {
 			this._close();
+			// Prevent the underlying device handle from being closed concurrently
+			this._busy = true;
 		}
 	}
 
@@ -637,6 +639,7 @@ class DeviceBase extends EventEmitter {
 			const emitEvent = (this._state === DeviceState.CLOSING);
 			this._state = DeviceState.CLOSED;
 			this._wantClose = false;
+			this._busy = false;
 			this._maxActiveReqs = null;
 			this._dfu = null;
 			this._fwVer = null;

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -127,7 +127,9 @@ class DeviceBase extends EventEmitter {
 		// Open USB device
 		this._log.trace('Opening device');
 		this._state = DeviceState.OPENING;
+		let devOpen = false;
 		return this._dev.open().then(() => {
+			devOpen = true;
 			// Normalize the device ID string
 			this._id = this._dev.serialNumber.replace(/[^\x20-\x7e]/g, '').toLowerCase();
 			this._log.trace(`Device ID: ${this._id}`);
@@ -157,6 +159,9 @@ class DeviceBase extends EventEmitter {
 			this.emit('open');
 			this._process();
 		}).catch(err => {
+			if (!devOpen) {
+				throw err;
+			}
 			return this._close(err).catch(ignore).then(() => {
 				throw err;
 			});


### PR DESCRIPTION
This is a workaround for https://github.com/node-usb/node-usb/pull/676.