### PR TITLE
Filter out null bytes from the firmware version returned by the device

### DIFF
--- a/src/device-base.js
+++ b/src/device-base.js
@@ -715,7 +715,9 @@ class DeviceBase extends EventEmitter {
 			wLength: proto.MIN_WLENGTH
 		};
 		return this._dev.transferIn(setup).then(data => {
-			return data.toString();
+			// filter out null bytes
+			const nullPos = data.indexOf(0);
+			return (nullPos === -1 ? data : data.slice(0, nullPos)).toString();
 		});
 	}
 

--- a/src/device-base.test.js
+++ b/src/device-base.test.js
@@ -267,6 +267,12 @@ describe('device-base', () => {
 					expect(dev.firmwareVersion).to.equal('1.0.0');
 				});
 
+				it('filters out null characters from the firmware version string', async () => {
+					usbDev.options.firmwareVersion = '1.0.0\x00';
+					await dev.open();
+					expect(dev.firmwareVersion).to.equal('1.0.0');
+				});
+
 				it('filters out non-printable ASCII characters from the device ID string', async () => {
 					usbDev.options.serialNumber = '222222222222222222222222\x00';
 					await dev.open();


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/121836

While testing https://github.com/particle-iot/particle-cli/pull/673 I got an error that 0.6.3 was not valid semver. It turns out the Photon sends `'0.6.3\x00\x00'`.
