### PR TITLE
Use @particle/device-os-protobuf instead of the proto submodule

### DIFF
--- a/src/cloud-device.js
+++ b/src/cloud-device.js
@@ -2,8 +2,7 @@ const { Request } = require('./request');
 const { fromProtobufEnum } = require('./protobuf-util');
 const usbProto = require('./usb-protocol');
 const { globalOptions } = require('./config');
-
-const proto = require('./protocol');
+const { definitions: proto } = require('@particle/device-os-protobuf');
 
 /**
  * Cloud connection status.

--- a/src/device.js
+++ b/src/device.js
@@ -5,12 +5,10 @@ const { fromProtobufEnum } = require('./protobuf-util');
 const usbProto = require('./usb-protocol');
 const { RequestError, NotFoundError, TimeoutError, StateError } = require('./error');
 const { globalOptions } = require('./config');
-
-const proto = require('./protocol');
-
 const DeviceOSProtobuf = require('@particle/device-os-protobuf');
+const proto = DeviceOSProtobuf.definitions;
 
-const FirmwareModuleDeprecated = fromProtobufEnum(DeviceOSProtobuf.definitions.FirmwareModuleType, {
+const FirmwareModuleDeprecated = fromProtobufEnum(proto.FirmwareModuleType, {
 	/** Bootloader module. */
 	BOOTLOADER: 'BOOTLOADER',
 	/** System part module. */

--- a/src/network-device.js
+++ b/src/network-device.js
@@ -2,7 +2,7 @@ const { Request } = require('./request');
 const { fromProtobufEnum } = require('./protobuf-util');
 const { convertBufferToMacAddress } = require('./address-util.js');
 const { globalOptions } = require('./config');
-const proto = require('./protocol');
+const { definitions: proto } = require('@particle/device-os-protobuf');
 const { Address4, Address6 } = require('ip-address');
 const { NotFoundError } = require('./error.js');
 

--- a/src/request.js
+++ b/src/request.js
@@ -1,4 +1,4 @@
-const proto = require('./protocol');
+const { definitions: proto } = require('@particle/device-os-protobuf');
 
 // Mapping of request types to Protobuf messages
 const Request = {

--- a/src/wifi-device-legacy.js
+++ b/src/wifi-device-legacy.js
@@ -5,8 +5,7 @@
  */
 const { Request } = require('./request');
 const { fromProtobufEnum, fromProtobufMessage, toProtobufMessage } = require('./protobuf-util');
-
-const proto = require('./protocol');
+const { definitions: proto } = require('@particle/device-os-protobuf');
 
 /**
  * WiFi antenna types.


### PR DESCRIPTION
The Particle USB library relies on the device-os-protobuf library, which is currently installed both as a direct dependency in the node_modules folder and included as a submodule called proto. This pull request streamlines the dependency management by eliminating the redundant submodule and exclusively utilizing the installed dependency within the node_modules folder.