### PR TITLE
Allow entering safe mode from DFU

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -292,6 +292,9 @@ class Device extends DeviceBase {
 	 * @return {Promise}
 	 */
 	enterSafeMode({ timeout = globalOptions.requestTimeout } = {}) {
+		if (this.isInDfuMode) {
+			return this._dfu.enterSafeMode();
+		}
 		return this.sendRequest(Request.SAFE_MODE, null /* msg */, { timeout });
 	}
 

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -352,8 +352,9 @@ class Dfu {
 				await this._clearStatus();
 			}
 
-			if (state.state !== DfuDeviceState.dfuIDLE && (!dnloadIdle || state.state !== DfuDeviceState.dfuDNLOAD_IDLE) &&
-					(!uploadIdle || state.state !== DfuDeviceState.dfuUPLOAD_IDLE)) {
+			if (state.state !== DfuDeviceState.dfuIDLE &&
+					!(dnloadIdle && state.state === DfuDeviceState.dfuDNLOAD_IDLE) &&
+					!(uploadIdle && state.state === DfuDeviceState.dfuUPLOAD_IDLE)) {
 				// If we are in some kind of an unknown state, issue DFU_CLRSTATUS, which may fail,
 				// but the device will go into dfuERROR state, so a subsequent DFU_CLRSTATUS will get us
 				// into dfuIDLE
@@ -366,8 +367,9 @@ class Dfu {
 
 		// Confirm we are in dfuIDLE or, optionally, in dfuDNLOAD_IDLE or dfuUPLOAD_IDLE
 		const state = await this._getStatus();
-		if (state.state !== DfuDeviceState.dfuIDLE && (!dnloadIdle || state.state !== DfuDeviceState.dfuDNLOAD_IDLE) &&
-				(!uploadIdle || state.state !== DfuDeviceState.dfuUPLOAD_IDLE)) {
+		if (state.state !== DfuDeviceState.dfuIDLE &&
+				!(dnloadIdle && state.state === DfuDeviceState.dfuDNLOAD_IDLE) &&
+				!(uploadIdle && state.state === DfuDeviceState.dfuUPLOAD_IDLE)) {
 			throw new DfuError('Invalid state');
 		}
 		return state;

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -211,7 +211,7 @@ class Dfu {
 		const data = Buffer.alloc(1);
 		data[0] = 0xfa; // Particle's extension
 		await this._sendDnloadRequest(data, 0 /* wValue */);
-		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST || state === DfuDeviceState.dfuDNLOAD_IDLE); // See leave()
+		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
 	}
 
 	/**

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -202,6 +202,19 @@ class Dfu {
 	}
 
 	/**
+	 * Enter safe mode.
+	 *
+	 * @returns {Promise}
+	 */
+	async enterSafeMode() {
+		await this._goIntoDfuIdleOrDfuDnloadIdle();
+		const data = Buffer.alloc(1);
+		data[0] = 0xfa; // Particle's extension
+		await this._sendDnloadRequest(data, 0 /* wValue */);
+		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST || state === DfuDeviceState.dfuDNLOAD_IDLE); // See leave()
+	}
+
+	/**
 	 * Set the alternate interface for DFU and initialize memory information.
 	 *
 	 * @param {number} setting - The alternate interface index to set.

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -879,7 +879,7 @@ class Dfu {
 			this._supportedDfuseCommands = [...data];
 		}
 		if (!this._supportedDfuseCommands.includes(cmd)) {
-			throw UnsupportedDfuseCommandError('Unsupported DfuSe command');
+			throw new UnsupportedDfuseCommandError('Unsupported DfuSe command');
 		}
 	}
 }

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -18,7 +18,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-const { DeviceError, UsbStallError, DeviceProtectionError } = require('./error');
+const { DeviceError, UsbStallError, DeviceProtectionError, UnsupportedDfuseCommandError } = require('./error');
 
 /**
  * A generic DFU error.
@@ -131,7 +131,8 @@ const DfuseCommand = {
 	DFUSE_COMMAND_GET_COMMAND: 0x00,
 	DFUSE_COMMAND_SET_ADDRESS_POINTER: 0x21,
 	DFUSE_COMMAND_ERASE: 0x41,
-	DFUSE_COMMAND_READ_UNPROTECT: 0x92
+	DFUSE_COMMAND_READ_UNPROTECT: 0x92,
+	DFUSE_COMMAND_ENTER_SAFE_MODE: 0xfa // Particle's extension
 };
 
 const DfuBmRequestType = {
@@ -170,6 +171,7 @@ class Dfu {
 		let desc = await this._getConfigDescriptor(0); // Use the default config
 		desc = this._parseConfigDescriptor(desc);
 		this._allInterfaces = desc.interfaces;
+		this._supportedDfuseCommands = [];
 	}
 
 	/**
@@ -189,7 +191,7 @@ class Dfu {
 	 * @return {Promise}
 	 */
 	async leave() {
-		await this._goIntoDfuIdleOrDfuDnloadIdle();
+		await this._goIntoIdleState({ dnloadIdle: true });
 
 		await this._sendDnloadRequest(Buffer.alloc(0), 2);
 
@@ -207,9 +209,10 @@ class Dfu {
 	 * @returns {Promise}
 	 */
 	async enterSafeMode() {
-		await this._goIntoDfuIdleOrDfuDnloadIdle();
+		await this._checkDfuseCommandSupported(DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE);
+		await this._goIntoIdleState({ dnloadIdle: true });
 		const data = Buffer.alloc(1);
-		data[0] = 0xfa; // Particle's extension
+		data[0] = DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE;
 		await this._sendDnloadRequest(data, 0 /* wValue */);
 		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
 	}
@@ -341,7 +344,7 @@ class Dfu {
 		}
 	}
 
-	async _goIntoDfuIdleOrDfuDnloadIdle() {
+	async _goIntoIdleState({ dnloadIdle = false, uploadIdle = false } = {}) {
 		try {
 			const state = await this._getStatus();
 			if (state.state === DfuDeviceState.dfuERROR) {
@@ -349,7 +352,8 @@ class Dfu {
 				await this._clearStatus();
 			}
 
-			if (state.state !== DfuDeviceState.dfuIDLE && state.state !== DfuDeviceState.dfuDNLOAD_IDLE) {
+			if (state.state !== DfuDeviceState.dfuIDLE && (!dnloadIdle || state.state !== DfuDeviceState.dfuDNLOAD_IDLE) &&
+					(!uploadIdle || state.state !== DfuDeviceState.dfuUPLOAD_IDLE)) {
 				// If we are in some kind of an unknown state, issue DFU_CLRSTATUS, which may fail,
 				// but the device will go into dfuERROR state, so a subsequent DFU_CLRSTATUS will get us
 				// into dfuIDLE
@@ -360,9 +364,10 @@ class Dfu {
 			await this._clearStatus();
 		}
 
-		// Confirm we are in dfuIDLE or dfuDNLOAD_IDLE
+		// Confirm we are in dfuIDLE or, optionally, in dfuDNLOAD_IDLE or dfuUPLOAD_IDLE
 		const state = await this._getStatus();
-		if (state.state !== DfuDeviceState.dfuIDLE && state.state !== DfuDeviceState.dfuDNLOAD_IDLE) {
+		if (state.state !== DfuDeviceState.dfuIDLE && (!dnloadIdle || state.state !== DfuDeviceState.dfuDNLOAD_IDLE) &&
+				(!uploadIdle || state.state !== DfuDeviceState.dfuUPLOAD_IDLE)) {
 			throw new DfuError('Invalid state');
 		}
 		return state;
@@ -551,9 +556,11 @@ class Dfu {
 		}
 
 		const commandNames = {
-			0x00: 'GET_COMMANDS',
-			0x21: 'SET_ADDRESS',
-			0x41: 'ERASE_SECTOR'
+			[DfuseCommand.DFUSE_COMMAND_GET_COMMAND]: 'GET_COMMANDS',
+			[DfuseCommand.DFUSE_COMMAND_SET_ADDRESS_POINTER]: 'SET_ADDRESS',
+			[DfuseCommand.DFUSE_COMMAND_ERASE]: 'ERASE_SECTOR',
+			[DfuseCommand.DFUSE_COMMAND_READ_UNPROTECT]: 'READ_UNPROTECT',
+			[DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE]: 'ENTER_SAFE_MODE',
 		};
 
 		const payload = Buffer.alloc(5);
@@ -862,6 +869,17 @@ class Dfu {
 		}
 		if (state.state !== DfuDeviceState.dfuIDLE) {
 			throw new Error('Failed to return to idle state after abort: state ' + state.state);
+		}
+	}
+
+	async _checkDfuseCommandSupported(cmd) {
+		if (!this._supportedDfuseCommands.length) {
+			await this._goIntoIdleState({ uploadIdle: true });
+			const data = await this._sendUploadReqest(DEFAULT_TRANSFER_SIZE, 0 /* value */); // Get command
+			this._supportedDfuseCommands = [...data];
+		}
+		if (!this._supportedDfuseCommands.includes(cmd)) {
+			throw UnsupportedDfuseCommandError('Unsupported DfuSe command');
 		}
 	}
 }

--- a/src/error.js
+++ b/src/error.js
@@ -120,6 +120,16 @@ class DeviceProtectionError extends DeviceError {
 	}
 }
 
+/**
+ * An error reported when the issued DfuSe command is not supported by the device.
+ */
+class UnsupportedDfuseCommandError extends DeviceError {
+	constructor(...args) {
+		super(...args);
+		this.name = this.constructor.name;
+	}
+}
+
 function assert(val, msg = null) {
 	if (!val) {
 		throw new InternalError(msg ? msg : 'Assertion failed');
@@ -139,5 +149,6 @@ module.exports = {
 	RequestError,
 	UsbStallError,
 	DeviceProtectionError,
+	UnsupportedDfuseCommandError,
 	assert
 };

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -6,7 +6,7 @@ const { WifiAntenna, WifiCipher, EapMethod, WifiSecurityEnum } = require('./wifi
 const { WifiSecurity } = require('./wifi-device-legacy');
 const { CloudConnectionStatus, ServerProtocol } = require('./cloud-device');
 const { Result } = require('./result');
-const { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError, InternalError, RequestError, DeviceProtectionError } = require('./error');
+const { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError, InternalError, RequestError, DeviceProtectionError, UnsupportedDfuseCommandError } = require('./error');
 const { config } = require('./config');
 const { setDevicePrototype } = require('./set-device-prototype');
 
@@ -69,6 +69,7 @@ module.exports = {
 	InternalError,
 	RequestError,
 	DeviceProtectionError,
+	UnsupportedDfuseCommandError,
 	getDevices,
 	openDeviceById,
 	openNativeUsbDevice,

--- a/test/support/fake-usb.js
+++ b/test/support/fake-usb.js
@@ -675,6 +675,10 @@ class Device {
 	get isOpen() {
 		return this._open;
 	}
+
+	get dfuClass() {
+		return this._dfu;
+	}
 }
 
 async function getUsbDevices(filters) {


### PR DESCRIPTION
Extend the `enterSafeMode()` method to use a custom DfuSe command for entering safe mode when the device is in DFU mode.

Test app:
```js
const { getDevices } = require('particle-usb');

async function run() {
  let dev;
  try {
    // Open the first found USB device
    const devs = await getDevices();
    if (!devs.length) {
      throw new Error('No devices found');
    }
    dev = devs[0];
    if (!dev.isInDfuMode) {
      throw new Error('Device is not in DFU mode');
    }
    await dev.open();

    await dev.enterSafeMode();

  } catch (err) {
    console.error(err);
    process.exit(1);
  } finally {
    if (dev) {
      await dev.close();
    }
  }
}

run();
```