### PR TITLE
getProtectionState handles devices in dfu mode

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -964,13 +964,7 @@ class Device extends DeviceBase {
 	 */
 	async getProtectionState() {
 		if (this.isInDfuMode) {
-			let allSegmentsProtected = true;
-			const memInfo = await this._dfu.getSegmentForInternalFlash();
-			memInfo.segments.forEach(s => {
-				if (!(s.erasable === true && s.writable === false && s.readable === false)) {
-					allSegmentsProtected = false;
-				}
-			});
+			const allSegmentsProtected = await this._dfu.getSegmentForInternalFlash();
 			// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.
 			// As a workaround, we use `null` to uniquely indicate the distinction.
 			return { protected: allSegmentsProtected, overridden: null };

--- a/src/device.js
+++ b/src/device.js
@@ -964,10 +964,7 @@ class Device extends DeviceBase {
 	 */
 	async getProtectionState() {
 		if (this.isInDfuMode) {
-			const allSegmentsProtected = await this._dfu.getSegmentForInternalFlash();
-			// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.
-			// As a workaround, we use `null` to uniquely indicate the distinction.
-			return { protected: allSegmentsProtected, overridden: null };
+			return this._dfu.getProtectionState();
 		}
 
 		const rep = await this.sendProtobufRequest('GetProtectedStateRequest');

--- a/src/device.js
+++ b/src/device.js
@@ -975,7 +975,9 @@ class Device extends DeviceBase {
 					});
 				}
 			});
-			return { protected: allSegmentsProtected };
+			// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.
+			// As a workaround, we use `null` to uniquely indicate the distinction.
+			return { protected: allSegmentsProtected, overridden: null };
 		}
 
 		const rep = await this.sendProtobufRequest('GetProtectedStateRequest');

--- a/src/device.js
+++ b/src/device.js
@@ -965,14 +965,10 @@ class Device extends DeviceBase {
 	async getProtectionState() {
 		if (this.isInDfuMode) {
 			let allSegmentsProtected = true;
-			const memMap = await this._dfu.getMemoryMap();
-			memMap.forEach(m => {
-				if (m.name === 'Internal Flash') {
-					m.segments.forEach(s => {
-						if (!(s.erasable === true && s.writable === false && s.readable === false)) {
-							allSegmentsProtected = false;
-						}
-					});
+			const memInfo = await this._dfu.getSegmentForInternalFlash();
+			memInfo.segments.forEach(s => {
+				if (!(s.erasable === true && s.writable === false && s.readable === false)) {
+					allSegmentsProtected = false;
 				}
 			});
 			// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.

--- a/src/device.js
+++ b/src/device.js
@@ -963,6 +963,21 @@ class Device extends DeviceBase {
 	 * @returns {GetProtectionStateResult}
 	 */
 	async getProtectionState() {
+		if (this.isInDfuMode) {
+			let allSegmentsProtected = true;
+			const memMap = await this._dfu.getMemoryMap();
+			memMap.forEach(m => {
+				if (m.name === 'Internal Flash') {
+					m.segments.forEach(s => {
+						if (!(s.erasable === true && s.writable === false && s.readable === false)) {
+							allSegmentsProtected = false;
+						}
+					});
+				}
+			});
+			return { protected: allSegmentsProtected };
+		}
+
 		const rep = await this.sendProtobufRequest('GetProtectedStateRequest');
 		const result = { protected: rep.state };
 		if (rep.overridden) {

--- a/src/dfu-device.js
+++ b/src/dfu-device.js
@@ -21,11 +21,6 @@ const DfuDevice = (base) => class extends base {
 		const buffer = await this._dfu.doUpload({ startAddr, maxSize: size, progress });
 		return buffer;
 	}
-
-	async getSegment(altSetting) {
-		const seg = await this._dfu.getSegment(altSetting);
-		return seg;
-	}
 };
 
 module.exports = {

--- a/src/dfu-device.js
+++ b/src/dfu-device.js
@@ -21,6 +21,11 @@ const DfuDevice = (base) => class extends base {
 		const buffer = await this._dfu.doUpload({ startAddr, maxSize: size, progress });
 		return buffer;
 	}
+
+	async getSegment(altSetting) {
+		const seg = await this._dfu.getSegment(altSetting);
+		return seg;
+	}
 };
 
 module.exports = {

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -218,16 +218,25 @@ class Dfu {
 		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
 	}
 
-	async getSegmentForInternalFlash() {
-		let allSegmentsProtected = true;
+	/**
+	 * Get the protection state of the device.
+	 * A device with protection enabled will have all segments not readable and not writeable.
+	 *
+	 * @return {Promise} Object with property 'protected'
+	 */
+	async getProtectionState() {
 		// setting 0 is for Internal Flash
 		await this.setAltSetting(0);
+
+		let allSegmentsProtected = true;
 		this._memoryInfo.segments.forEach(s => {
 			if (!(s.erasable === true && s.writable === false && s.readable === false)) {
 				allSegmentsProtected = false;
 			}
 		});
-		return allSegmentsProtected;
+		// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.
+		// As a workaround, we use `null` to uniquely indicate the distinction.
+		return { protected: allSegmentsProtected, overridden: null };
 	}
 
 	/**

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -155,7 +155,6 @@ class Dfu {
 		this._alternate = DEFAULT_ALTERNATE;
 		this._claimed = false;
 		this._memoryInfo = null;
-		this._memoryMap = [];
 		this._transferSize = DEFAULT_TRANSFER_SIZE;
 		this._allInterfaces = [];
 	}

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -218,13 +218,9 @@ class Dfu {
 		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
 	}
 
-	async getMemoryMap() {
-		for (const i of this._allInterfaces) {
-			const ifaceName = await this._getStringDescriptor(i.iInterface);
-			const memInfo = this._parseMemoryDescriptor(ifaceName);
-			this._memoryMap.push(memInfo);
-		}
-		return this._memoryMap;
+	async getSegmentForInternalFlash() {
+		await this.setAltSetting(0);
+		return this._memoryInfo;
 	}
 
 	/**

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -219,8 +219,15 @@ class Dfu {
 	}
 
 	async getSegmentForInternalFlash() {
+		let allSegmentsProtected = true;
+		// setting 0 is for Internal Flash
 		await this.setAltSetting(0);
-		return this._memoryInfo;
+		this._memoryInfo.segments.forEach(s => {
+			if (!(s.erasable === true && s.writable === false && s.readable === false)) {
+				allSegmentsProtected = false;
+			}
+		});
+		return allSegmentsProtected;
 	}
 
 	/**

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -155,6 +155,7 @@ class Dfu {
 		this._alternate = DEFAULT_ALTERNATE;
 		this._claimed = false;
 		this._memoryInfo = null;
+		this._memoryMap = [];
 		this._transferSize = DEFAULT_TRANSFER_SIZE;
 		this._allInterfaces = [];
 	}
@@ -215,6 +216,15 @@ class Dfu {
 		data[0] = DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE;
 		await this._sendDnloadRequest(data, 0 /* wValue */);
 		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
+	}
+
+	async getMemoryMap() {
+		for (const i of this._allInterfaces) {
+			const ifaceName = await this._getStringDescriptor(i.iInterface);
+			const memInfo = this._parseMemoryDescriptor(ifaceName);
+			this._memoryMap.push(memInfo);
+		}
+		return this._memoryMap;
 	}
 
 	/**

--- a/src/dfu.test.js
+++ b/src/dfu.test.js
@@ -340,7 +340,7 @@ describe('dfu', () => {
 
 
 	describe('_doUploadImpl', () => {
-		it('should perform upload with progress', async () => {
+		it('performs upload with progress', async () => {
 			const maxSize = 40960;
 			const firstBlock = 0;
 			const logger = {
@@ -365,7 +365,7 @@ describe('dfu', () => {
 	});
 
 	describe('getProtectionState', () => {
-		it('should return that all segments are protected', async () => {
+		it('returns that all segments are protected', async () => {
 			const dfu = new Dfu();
 			sinon.stub(dfu, 'setAltSetting').resolves();
 			const internalFlashDesc = {
@@ -412,7 +412,7 @@ describe('dfu', () => {
 			expect(res.protected).to.eql(true);
 		});
 
-		it('should return that all segments are not protected', async () => {
+		it('returns that all segments are not protected', async () => {
 			const dfu = new Dfu();
 			sinon.stub(dfu, 'setAltSetting').resolves();
 			const internalFlashDesc = {

--- a/src/dfu.test.js
+++ b/src/dfu.test.js
@@ -363,4 +363,100 @@ describe('dfu', () => {
 			expect(data.length).equal(maxSize);
 		});
 	});
+
+	describe('getProtectionState', () => {
+		it('should return that all segments are protected', async () => {
+			const dfu = new Dfu();
+			sinon.stub(dfu, 'setAltSetting').resolves();
+			const internalFlashDesc = {
+				'name': 'Internal Flash',
+				'segments': [
+					{
+						'start': 134217728,
+						'sectorSize': 16384,
+						'end': 134266880,
+						'readable': false,
+						'erasable': true,
+						'writable': false
+					},
+					{
+						'start': 134266880,
+						'sectorSize': 16384,
+						'end': 134283264,
+						'readable': false,
+						'erasable': true,
+						'writable': false
+					},
+					{
+						'start': 134283264,
+						'sectorSize': 65536,
+						'end': 134348800,
+						'readable': false,
+						'erasable': true,
+						'writable': false
+					},
+					{
+						'start': 134348800,
+						'sectorSize': 131072,
+						'end': 135266304,
+						'readable': false,
+						'erasable': true,
+						'writable': false
+					}
+				]
+			};
+			dfu._memoryInfo = internalFlashDesc;
+
+			const res = await dfu.getProtectionState();
+
+			expect(res.protected).to.eql(true);
+		});
+
+		it('should return that all segments are not protected', async () => {
+			const dfu = new Dfu();
+			sinon.stub(dfu, 'setAltSetting').resolves();
+			const internalFlashDesc = {
+				'name': 'Internal Flash',
+				'segments': [
+					{
+						'start': 134217728,
+						'sectorSize': 16384,
+						'end': 134266880,
+						'readable': true,
+						'erasable': false,
+						'writable': false
+					},
+					{
+						'start': 134266880,
+						'sectorSize': 16384,
+						'end': 134283264,
+						'readable': true,
+						'erasable': true,
+						'writable': true
+					},
+					{
+						'start': 134283264,
+						'sectorSize': 65536,
+						'end': 134348800,
+						'readable': true,
+						'erasable': true,
+						'writable': true
+					},
+					{
+						'start': 134348800,
+						'sectorSize': 131072,
+						'end': 135266304,
+						'readable': true,
+						'erasable': true,
+						'writable': true
+					}
+				]
+			};
+			dfu._memoryInfo = internalFlashDesc;
+
+			const res = await dfu.getProtectionState();
+
+			expect(res.protected).to.eql(false);
+		});
+	});
 });


### PR DESCRIPTION
The device's `getProtectionState` API provides information about the device's protection status. 

This PR enhances the existing API by adding support for DFU (Device Firmware Upgrade) devices.

### How this works

- **DFU Mode Detection**: If the device is in DFU mode, the API retrieves the memory map, which contains information about the device's flash segments.
- **Protection Status Evaluation**: For Internal Flash segments, the API checks the protection criteria:
If a segment is not readable, not writable, but is erasable, the device is considered Protected.
If any segment does not meet the above criteria, the device is classified as either an Open Device or a Protected Device (Service Mode).


