### PR TITLE
Allow disabling service mode when the device is in DFU mode

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -925,6 +925,13 @@ class Device extends DeviceBase {
 	 * @returns {Promise<UnprotectDeviceResult>}
 	 */
 	async unprotectDevice({ action, serverNonce, serverSignature, serverPublicKeyFingerprint }) {
+		if (this.isInDfuMode) {
+			if (action !== 'reset') {
+				throw new StateError('Cannot perform operation when device is in DFU mode');
+			}
+			await this._dfu.clearSecurityModeOverride();
+			return;
+		}
 		let req;
 		switch (action) {
 			case 'prepare': {

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -219,7 +219,7 @@ class Dfu {
 	}
 
 	/**
-	 * Enter safe mode.
+	 * Re-enable device protection.
 	 *
 	 * @returns {Promise}
 	 */

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -132,7 +132,8 @@ const DfuseCommand = {
 	DFUSE_COMMAND_SET_ADDRESS_POINTER: 0x21,
 	DFUSE_COMMAND_ERASE: 0x41,
 	DFUSE_COMMAND_READ_UNPROTECT: 0x92,
-	DFUSE_COMMAND_ENTER_SAFE_MODE: 0xfa // Particle's extension
+	DFUSE_COMMAND_ENTER_SAFE_MODE: 0xfa, // Particle's extension
+	DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE: 0xfb // ditto
 };
 
 const DfuBmRequestType = {
@@ -215,6 +216,17 @@ class Dfu {
 		data[0] = DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE;
 		await this._sendDnloadRequest(data, 0 /* wValue */);
 		await this._pollUntil((state) => state === DfuDeviceState.dfuMANIFEST);
+	}
+
+	/**
+	 * Enter safe mode.
+	 *
+	 * @returns {Promise}
+	 */
+	async clearSecurityModeOverride() {
+		await this._checkDfuseCommandSupported(DfuseCommand.DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE);
+		await this._goIntoIdleState({ dnloadIdle: true });
+		await this._dfuseCommand(DfuseCommand.DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE);
 	}
 
 	/**
@@ -584,6 +596,7 @@ class Dfu {
 			[DfuseCommand.DFUSE_COMMAND_ERASE]: 'ERASE_SECTOR',
 			[DfuseCommand.DFUSE_COMMAND_READ_UNPROTECT]: 'READ_UNPROTECT',
 			[DfuseCommand.DFUSE_COMMAND_ENTER_SAFE_MODE]: 'ENTER_SAFE_MODE',
+			[DfuseCommand.DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE]: 'CLEAR_SECURITY_MODE_OVERRIDE'
 		};
 
 		const payload = Buffer.alloc(5);


### PR DESCRIPTION
Add support for the new custom DfuSe command that allows re-enabling device protection in DFU mode:

```js
assert(dev.isInDfuMode);
await dev.unprotectDevice({ action: 'reset' });
```

### References

- https://github.com/particle-iot/device-os/pull/2802