### PR TITLE
Accurate device state detection for devices in DFU

### DIFF
--- a/src/dfu.js
+++ b/src/dfu.js
@@ -237,9 +237,8 @@ class Dfu {
 	 */
 	async getProtectionState() {
 		try {
-			const res = await this._getStringDescriptor(0xfe);
-			const state = res.split(';').find(kv => kv.startsWith('sm='))?.split('=')[1];
-	
+			const res = await this._getStringDescriptor(0xfa);
+			const state = res.split(';').find(kv => kv.startsWith('sm='))?.split('=')[1]?.trim().charAt(0);
 			switch (state) {
 				case 'o': return { protected: false, overridden: false };
 				case 'p': return { protected: true };
@@ -247,6 +246,7 @@ class Dfu {
 				default: throw new Error('Unknown device state');
 			}
 		} catch (error) {
+			console.warn('Failed to get protection state', error);
 			// Fallback for devices with Device-OS < 6.1.2
 			await this.setAltSetting(0); // setting 0 is for Internal Flash
 	

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -238,7 +238,7 @@ class Dfu {
 	async getProtectionState() {
 		try {
 			const res = await this._getStringDescriptor(0xfe);
-			const state = res.split(';').find(kv => kv.startsWith('s='))?.split('=')[1];
+			const state = res.split(';').find(kv => kv.startsWith('sm='))?.split('=')[1];
 	
 			switch (state) {
 				case 'o': return { protected: false, overridden: false };

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -236,18 +236,27 @@ class Dfu {
 	 * @return {Promise} Object with property 'protected'
 	 */
 	async getProtectionState() {
-		// setting 0 is for Internal Flash
-		await this.setAltSetting(0);
-
-		let allSegmentsProtected = true;
-		this._memoryInfo.segments.forEach(s => {
-			if (!(s.erasable === true && s.writable === false && s.readable === false)) {
-				allSegmentsProtected = false;
+		try {
+			const res = await this._getStringDescriptor(0xfe);
+			const state = res.split(';').find(kv => kv.startsWith('s='))?.split('=')[1];
+	
+			switch (state) {
+				case 'o': return { protected: false, overridden: false };
+				case 'p': return { protected: true };
+				case 's': return { protected: false, overridden: true };
+				default: throw new Error('Unknown device state');
 			}
-		});
-		// FIXME: Currently, device-os does not reliably distinguish the `overridden` value for different protection modes.
-		// As a workaround, we use `null` to uniquely indicate the distinction.
-		return { protected: allSegmentsProtected, overridden: null };
+		} catch (error) {
+			// Fallback for devices with Device-OS < 6.1.2
+			await this.setAltSetting(0); // setting 0 is for Internal Flash
+	
+			const allSegmentsProtected = this._memoryInfo.segments.every(s => 
+				s.erasable === true && s.writable === false && s.readable === false
+			);
+	
+			// Use `null` for `overridden` to indicate older Device-OS version
+			return { protected: allSegmentsProtected, overridden: null };
+		}
 	}
 
 	/**

--- a/src/dfu.js
+++ b/src/dfu.js
@@ -238,7 +238,7 @@ class Dfu {
 	async getProtectionState() {
 		try {
 			const res = await this._getStringDescriptor(0xfa);
-			const state = res.split(';').find(kv => kv.startsWith('sm='))?.split('=')[1]?.trim().charAt(0);
+			const state = res.split(';').find(kv => kv.startsWith('sm=')).split('=')[1].trim().charAt(0);
 			switch (state) {
 				case 'o': return { protected: false, overridden: false };
 				case 'p': return { protected: true };
@@ -246,15 +246,14 @@ class Dfu {
 				default: throw new Error('Unknown device state');
 			}
 		} catch (error) {
-			console.warn('Failed to get protection state', error);
 			// Fallback for devices with Device-OS < 6.1.2
 			await this.setAltSetting(0); // setting 0 is for Internal Flash
-	
-			const allSegmentsProtected = this._memoryInfo.segments.every(s => 
+
+			const allSegmentsProtected = this._memoryInfo.segments.every(s =>
 				s.erasable === true && s.writable === false && s.readable === false
 			);
-	
-			// Use `null` for `overridden` to indicate older Device-OS version
+
+			// Use `null` for `overridden` since we cannot distinguish between Open and Service Mode
 			return { protected: allSegmentsProtected, overridden: null };
 		}
 	}

--- a/src/dfu.test.js
+++ b/src/dfu.test.js
@@ -367,7 +367,7 @@ describe('dfu', () => {
 	describe('getProtectionState', () => {
 		it ('detects an Open Device from string desc for Device-OS >= 6.1.2', async () => {
 			const dfu = new Dfu();
-			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=o");
+			sinon.stub(dfu, '_getStringDescriptor').resolves('sm=o');
 
 			const res = await dfu.getProtectionState();
 			expect(res.protected).to.eql(false);
@@ -376,7 +376,7 @@ describe('dfu', () => {
 
 		it ('detects a Protected Device from string desc for Device-OS >= 6.1.2', async () => {
 			const dfu = new Dfu();
-			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=p");
+			sinon.stub(dfu, '_getStringDescriptor').resolves('sm=p');
 
 			const res = await dfu.getProtectionState();
 			expect(res.protected).to.eql(true);
@@ -384,7 +384,7 @@ describe('dfu', () => {
 
 		it ('detects a Protected Device in Service Mode from string desc for Device-OS >= 6.1.2', async () => {
 			const dfu = new Dfu();
-			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=s");
+			sinon.stub(dfu, '_getStringDescriptor').resolves('sm=s');
 
 			const res = await dfu.getProtectionState();
 			expect(res.protected).to.eql(false);

--- a/src/dfu.test.js
+++ b/src/dfu.test.js
@@ -365,8 +365,35 @@ describe('dfu', () => {
 	});
 
 	describe('getProtectionState', () => {
+		it ('detects an Open Device from string desc for Device-OS >= 6.1.2', async () => {
+			const dfu = new Dfu();
+			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=o");
+
+			const res = await dfu.getProtectionState();
+			expect(res.protected).to.eql(false);
+			expect(res.overridden).to.eql(false);
+		});
+
+		it ('detects a Protected Device from string desc for Device-OS >= 6.1.2', async () => {
+			const dfu = new Dfu();
+			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=p");
+
+			const res = await dfu.getProtectionState();
+			expect(res.protected).to.eql(true);
+		});
+
+		it ('detects a Protected Device in Service Mode from string desc for Device-OS >= 6.1.2', async () => {
+			const dfu = new Dfu();
+			sinon.stub(dfu, '_getStringDescriptor').resolves("sm=s");
+
+			const res = await dfu.getProtectionState();
+			expect(res.protected).to.eql(false);
+			expect(res.overridden).to.eql(true);
+		});
+
 		it('returns that all segments are protected', async () => {
 			const dfu = new Dfu();
+			sinon.stub(dfu, '_getStringDescriptor').rejects('random error');
 			sinon.stub(dfu, 'setAltSetting').resolves();
 			const internalFlashDesc = {
 				'name': 'Internal Flash',
@@ -409,11 +436,13 @@ describe('dfu', () => {
 
 			const res = await dfu.getProtectionState();
 
+			expect(dfu.setAltSetting).to.have.been.calledOnce;
 			expect(res.protected).to.eql(true);
 		});
 
 		it('returns that all segments are not protected', async () => {
 			const dfu = new Dfu();
+			sinon.stub(dfu, '_getStringDescriptor').rejects('random error');
 			sinon.stub(dfu, 'setAltSetting').resolves();
 			const internalFlashDesc = {
 				'name': 'Internal Flash',
@@ -456,6 +485,7 @@ describe('dfu', () => {
 
 			const res = await dfu.getProtectionState();
 
+			expect(dfu.setAltSetting).to.have.been.calledOnce;
 			expect(res.protected).to.eql(false);
 		});
 	});


### PR DESCRIPTION
### Problem

Currently, there is no way to distinguish between Open and Protected Devices in Service Mode when the device is in DFU mode.

### Solution

This PR obtains and parses the result of the string descriptor with the correct index for the device state
Device-OS changes are in this PR (estimated 6.1.2)

### Testing

Use this Device-OS PR - 
Use a script like this 
```
#!/usr/bin/env node

const { getDevices } = require('/path/to/particle-usb');

async function run() {
  let dev;
  try {
    // Open the first found USB device
    const devs = await getDevices();
    if (!devs.length) {
      throw new Error('No devices found');
    }
    dev = devs[0];
    if (!dev.isInDfuMode) {
      throw new Error('Device is not in DFU mode');
    }
    await dev.open();
    const res = await dev.getProtectionState();
    console.log('Protection state:', res);

  } catch (err) {
    console.error(err);
    process.exit(1);
  } finally {
    if (dev) {
      await dev.close();
    }
  }
}

run();
```