### PR TITLE
Ignore platforms without support for control requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@particle/async-utils": "^4.0.2",
-        "@particle/device-constants": "^3.7.0",
+        "@particle/device-constants": "^3.8.3",
         "buffer": "^6.0.3",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.7.0.tgz",
-      "integrity": "sha512-B6lPf5L0Zgffg/dbgkTAj2Wyk7AAKFqy7rMmL3pqiY0m/gYsVDhvPoqUeyeFKg8jIIkjGKjXHjLywGWBZ/8V1Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.3.tgz",
+      "integrity": "sha512-GgHyErfr8hvpfHvtCMsAnFpNMlrZgqrDUY/6LRzjHjpJhBI1ko4tj94t5FUMCSZ9ptXaXi5iaXa0kJZsAmVRmg==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -13348,9 +13348,9 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.7.0.tgz",
-      "integrity": "sha512-B6lPf5L0Zgffg/dbgkTAj2Wyk7AAKFqy7rMmL3pqiY0m/gYsVDhvPoqUeyeFKg8jIIkjGKjXHjLywGWBZ/8V1Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.3.tgz",
+      "integrity": "sha512-GgHyErfr8hvpfHvtCMsAnFpNMlrZgqrDUY/6LRzjHjpJhBI1ko4tj94t5FUMCSZ9ptXaXi5iaXa0kJZsAmVRmg==",
       "dev": true
     },
     "@particle/device-os-protobuf": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@particle/async-utils": "^4.0.2",
-    "@particle/device-constants": "^3.7.0",
+    "@particle/device-constants": "^3.8.3",
     "buffer": "^6.0.3",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/src/device-base.js
+++ b/src/device-base.js
@@ -817,5 +817,6 @@ module.exports = {
 	DeviceBase,
 	getDevices,
 	openDeviceById,
-	openNativeUsbDevice
+	openNativeUsbDevice,
+	platformForUsbIds // For testing
 };

--- a/src/device.test.js
+++ b/src/device.test.js
@@ -5,7 +5,6 @@
  */
 const { sinon, expect } = require('../test/support');
 const { UsbDevice } = require('./usb-device-node');
-const { PLATFORMS } = require('./platforms');
 const { Device } = require('./device');
 const { platformForUsbIds } = require('./device-base');
 const DeviceOSProtobuf = require('@particle/device-os-protobuf');
@@ -300,8 +299,9 @@ describe('Device', () => {
 		let device;
 
 		beforeEach(() => {
+			const usbDev = new UsbDevice({});
 			const platform = platformForUsbIds(0x2b04, 0xc020); // P2
-			device = new Device(null /* dev */, platform);
+			device = new Device(usbDev, platform);
 		});
 
 		describe('sendProtobufRequest', () => {

--- a/src/edl-device.js
+++ b/src/edl-device.js
@@ -1,0 +1,33 @@
+const { getUsbDevices } = require('./usb-device-node');
+
+const VENDOR_ID_QUALCOMM = 0x05c6;
+const PRODUCT_ID_EDL_DEVICE = 0x9008;
+
+class EdlDevice {
+	constructor({ serialNumber }) {
+		this.serialNumber = serialNumber;
+	}
+
+	static async getEdlDevices() {
+		const filters = [
+			{
+				vendorId: VENDOR_ID_QUALCOMM,
+				productId: PRODUCT_ID_EDL_DEVICE
+			}
+		];
+		const devs = await getUsbDevices(filters);
+		return Promise.all(devs.map(async (dev) => {
+			try {
+				await dev.open();
+				const serialNumber = dev.productName.replace(/.*_SN:/, '');
+				return new EdlDevice({ serialNumber });
+			} finally {
+				dev.close();
+			}
+		}));
+	}
+}
+
+module.exports = {
+	EdlDevice
+};

--- a/src/edl-device.test.js
+++ b/src/edl-device.test.js
@@ -1,0 +1,25 @@
+const { fakeUsb, expect } = require('../test/support');
+const proxyquire = require('proxyquire');
+
+const { EdlDevice } = proxyquire('./edl-device', {
+	'./usb-device-node': fakeUsb
+});
+
+describe('EdlDevice', () => {
+	afterEach(() => {
+		// "Detach" all USB devices
+		fakeUsb.clearDevices();
+	});
+
+	describe('getEdlDevices()', () => {
+		it('enumerates EDL devices with their serial number', async () => {
+			fakeUsb.addDevice({ vendorId: 0xaaaa, productId: 0xaaaa });
+			fakeUsb.addDevice({ vendorId: 0x05c6, productId: 0x9008, productName: 'QUSB_BULK_CID:042F_SN:C6ACF5F8' });
+			const serialNumbers = ['C6ACF5F8'];
+
+			const devs = await EdlDevice.getEdlDevices();
+
+			expect(devs.map(dev => dev.serialNumber)).to.have.all.members(serialNumbers);
+		});
+	});
+});

--- a/src/linux-device.js
+++ b/src/linux-device.js
@@ -1,13 +1,20 @@
 const { DeviceBase } = require('./device-base');
+const { DeviceMode } = require('./device');
 
+/**
+ * Base class for Linux devices.
+ *
+ * This class is not meant to be instantiated directly. Use {@link getDevices} and
+ * {@link openDeviceById} to create device instances.
+ */
 class LinuxDevice extends DeviceBase {
-
-	async _getFirmwareVersion() {
-		return {};
-	}
-
+	/**
+	 * Get the device mode.
+	 *
+	 * @return {Promise<DeviceMode>}
+	 */
 	async getDeviceMode() {
-		return 'NORMAL';
+		return DeviceMode.NORMAL;
 	}
 }
 

--- a/src/linux-device.js
+++ b/src/linux-device.js
@@ -1,0 +1,16 @@
+const { DeviceBase } = require('./device-base');
+
+class LinuxDevice extends DeviceBase {
+
+	async _getFirmwareVersion() {
+		return {};
+	}
+
+	async getDeviceMode() {
+		return 'NORMAL';
+	}
+}
+
+module.exports = {
+	LinuxDevice
+};

--- a/src/particle-usb.js
+++ b/src/particle-usb.js
@@ -9,6 +9,7 @@ const { Result } = require('./result');
 const { DeviceError, NotFoundError, NotAllowedError, StateError, TimeoutError, MemoryError, ProtocolError, UsbError, InternalError, RequestError, DeviceProtectionError, UnsupportedDfuseCommandError } = require('./error');
 const { config } = require('./config');
 const { setDevicePrototype } = require('./set-device-prototype');
+const { EdlDevice } = require('./edl-device');
 
 /**
  * Enumerate Particle USB devices attached to the host.
@@ -45,6 +46,15 @@ function openNativeUsbDevice(nativeUsbDevice, options) {
 	return openUsbNativeUsbDevice(nativeUsbDevice, options).then(dev => setDevicePrototype(dev));
 }
 
+/**
+ * Get devices in Qualcomm EDL mode.
+ *
+ * @return {Promise<Array<EdlDevice>>}
+ */
+function getEdlDevices() {
+	return EdlDevice.getEdlDevices();
+}
+
 module.exports = {
 	PollingPolicy,
 	FirmwareModule,
@@ -73,5 +83,6 @@ module.exports = {
 	getDevices,
 	openDeviceById,
 	openNativeUsbDevice,
+	getEdlDevices,
 	config
 };

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -5,7 +5,7 @@ const PLATFORMS = [];
 for (let p of Object.values(deviceConstants)) {
 	p = clone(p);
 	if (p.usb) {
-		if (p.quirks && p.quirks.controlRequestsNotSupported) {
+		if (p.usb.quirks && p.usb.quirks.controlRequestsNotSupported) {
 			continue;
 		}
 		p.usb = parseUsbInfo(p.usb);

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -5,9 +5,6 @@ const PLATFORMS = [];
 for (let p of Object.values(deviceConstants)) {
 	p = clone(p);
 	if (p.usb) {
-		if (p.usb.quirks && p.usb.quirks.controlRequestsNotSupported) {
-			continue;
-		}
 		p.usb = parseUsbInfo(p.usb);
 	}
 	if (p.dfu) {

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -1,15 +1,20 @@
 const deviceConstants = require('@particle/device-constants');
 
-const PLATFORMS = Object.values(clone(deviceConstants)); // TODO: (Julien) .filter((platform) => platform.features.include('usb-requests'));
+const PLATFORMS = []
 
-PLATFORMS.forEach((platform) => {
-	if (platform.usb) {
-		platform.usb = parseUsbInfo(platform.usb);
+for (let p of Object.values(deviceConstants)) {
+	p = clone(p);
+	if (p.usb) {
+		if (p.quirks && p.quirks.controlRequestsNotSupported) {
+			continue;
+		}
+		p.usb = parseUsbInfo(p.usb);
 	}
-	if (platform.dfu) {
-		platform.dfu = parseUsbInfo(platform.dfu);
+	if (p.dfu) {
+		p.dfu = parseUsbInfo(p.dfu);
 	}
-});
+	PLATFORMS.push(p);
+}
 
 // Convert the "0x2b04" id strings to 0x2b04 numbers
 function parseUsbInfo({ vendorId, productId, quirks }) {

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -3,6 +3,9 @@ const deviceConstants = require('@particle/device-constants');
 const PLATFORMS = [];
 
 for (let p of Object.values(deviceConstants)) {
+	if (!p.usb && !p.dfu) {
+		continue;
+	}
 	p = clone(p);
 	if (p.usb) {
 		p.usb = parseUsbInfo(p.usb);

--- a/src/platforms.js
+++ b/src/platforms.js
@@ -1,6 +1,6 @@
 const deviceConstants = require('@particle/device-constants');
 
-const PLATFORMS = []
+const PLATFORMS = [];
 
 for (let p of Object.values(deviceConstants)) {
 	p = clone(p);

--- a/src/set-device-prototype.js
+++ b/src/set-device-prototype.js
@@ -7,6 +7,7 @@ const { CloudDevice } = require('./cloud-device');
 const { Gen3Device } = require('./gen3-device');
 const { NetworkDevice } = require('./network-device');
 const { DfuDevice } = require('./dfu-device');
+const { LinuxDevice } = require('./linux-device');
 
 /**
  * This constant has a structure like this:
@@ -17,21 +18,26 @@ const { DfuDevice } = require('./dfu-device');
 // }
  */
 const DEVICE_CLASSES = PLATFORMS.reduce((classes, platform) => {
-	let klass = class extends NetworkDevice(Device) {};
-	if (platform.generation === 3) {
-		klass = class extends Gen3Device(klass) {};
-	}
-	if (platform.features.includes('cellular')) {
-		klass = class extends CellularDevice(klass) {};
-	}
-	if (platform.features.includes('wifi')) {
-		if (platform.generation === 2 || platform.generation === 1) {
-			klass = class extends WifiDeviceLegacy(klass) {};
-		} else {
-			klass = class extends WifiDevice(klass) {};
+	let klass;
+	if (platform.features.includes('linux')) {
+		klass = LinuxDevice;
+	} else {
+		klass = class extends NetworkDevice(Device) {};
+		if (platform.generation === 3) {
+			klass = class extends Gen3Device(klass) {};
 		}
+		if (platform.features.includes('cellular')) {
+			klass = class extends CellularDevice(klass) {};
+		}
+		if (platform.features.includes('wifi')) {
+			if (platform.generation === 2 || platform.generation === 1) {
+				klass = class extends WifiDeviceLegacy(klass) {};
+			} else {
+				klass = class extends WifiDevice(klass) {};
+			}
+		}
+		klass = class extends CloudDevice(klass) {};
 	}
-	klass = class extends CloudDevice(klass) {};
 
 	classes[platform.name] = klass;
 

--- a/src/set-device-prototype.test.js
+++ b/src/set-device-prototype.test.js
@@ -1,6 +1,7 @@
 const { sinon, expect } = require('../test/support');
 const { setDevicePrototype } = require('./set-device-prototype');
 const { Device } = require('./device');
+const { LinuxDevice } = require('./linux-device');
 const { PLATFORMS } = require('./platforms');
 
 describe('setDevicePrototype(), a helper function that sets prototype and inheritance hierarchy based on hardware platform', () => {
@@ -19,7 +20,11 @@ describe('setDevicePrototype(), a helper function that sets prototype and inheri
 		for (const platformName of relevantPlatformNames) {
 			const fakeDevice = { type: platformName };
 			const result = setDevicePrototype(fakeDevice);
-			expect(result).to.be.an.instanceOf(Device);
+			if (platformName === 'tachyon') {
+				expect(result).to.be.an.instanceOf(LinuxDevice);
+			} else {
+				expect(result).to.be.an.instanceOf(Device);
+			}
 		}
 	});
 });

--- a/src/usb-device-webusb.js
+++ b/src/usb-device-webusb.js
@@ -140,6 +140,10 @@ class UsbDevice {
 		return this._dev.productId;
 	}
 
+	get productName() {
+		return this._dev.productName;
+	}
+
 	get serialNumber() {
 		return this._dev.serialNumber;
 	}

--- a/test/e2e/browser.e2e.js
+++ b/test/e2e/browser.e2e.js
@@ -191,6 +191,7 @@ describe('Browser Usage', () => {
 		const height = 768;
 		const width = 1024;
 		const options = {
+			// TODO (Sergey): Disabled sandboxing to make CI happy. Updating puppeteer will likely resolve this
 			args: [`--window-size=${width},${height}`, '--no-sandbox'],
 			defaultViewport: { width, height }
 		};

--- a/test/e2e/browser.e2e.js
+++ b/test/e2e/browser.e2e.js
@@ -191,7 +191,7 @@ describe('Browser Usage', () => {
 		const height = 768;
 		const width = 1024;
 		const options = {
-			args: [`--window-size=${width},${height}`],
+			args: [`--window-size=${width},${height}`, '--no-sandbox'],
 			defaultViewport: { width, height }
 		};
 

--- a/test/support/fake-usb.js
+++ b/test/support/fake-usb.js
@@ -660,6 +660,10 @@ class Device {
 		return this._opts.productId;
 	}
 
+	get productName() {
+		return this._opts.productName;
+	}
+
 	get serialNumber() {
 		return this._opts.serialNumber;
 	}


### PR DESCRIPTION
Enumerating USB devices fails if a Tachyon device is attached to the host.

See also https://github.com/particle-iot-inc/device-constants/pull/48.