### PR TITLE
EDL device ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@particle/async-utils": "^4.0.2",
-        "@particle/device-constants": "^3.8.3",
+        "@particle/device-constants": "^3.8.4",
         "buffer": "^6.0.3",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.3.tgz",
-      "integrity": "sha512-GgHyErfr8hvpfHvtCMsAnFpNMlrZgqrDUY/6LRzjHjpJhBI1ko4tj94t5FUMCSZ9ptXaXi5iaXa0kJZsAmVRmg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.4.tgz",
+      "integrity": "sha512-Gz3rxpPRYVorrvN1Km+fNh/H0fxXmVJQngKjmHMqgOBU4yiNCIVpxSsPJgQX7PD4ZKQ6kaUEuoxFjJ1psq/+hw==",
       "dev": true,
       "engines": {
         "node": ">=12.x",
@@ -13348,9 +13348,9 @@
       "dev": true
     },
     "@particle/device-constants": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.3.tgz",
-      "integrity": "sha512-GgHyErfr8hvpfHvtCMsAnFpNMlrZgqrDUY/6LRzjHjpJhBI1ko4tj94t5FUMCSZ9ptXaXi5iaXa0kJZsAmVRmg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.8.4.tgz",
+      "integrity": "sha512-Gz3rxpPRYVorrvN1Km+fNh/H0fxXmVJQngKjmHMqgOBU4yiNCIVpxSsPJgQX7PD4ZKQ6kaUEuoxFjJ1psq/+hw==",
       "dev": true
     },
     "@particle/device-os-protobuf": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@particle/async-utils": "^4.0.2",
-    "@particle/device-constants": "^3.8.3",
+    "@particle/device-constants": "^3.8.4",
     "buffer": "^6.0.3",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",

--- a/src/edl-device.js
+++ b/src/edl-device.js
@@ -1,4 +1,5 @@
 const { getUsbDevices } = require('./usb-device-node');
+const deviceConstants = require('@particle/device-constants');
 
 const VENDOR_ID_QUALCOMM = 0x05c6;
 const PRODUCT_ID_EDL_DEVICE = 0x9008;
@@ -6,6 +7,16 @@ const PRODUCT_ID_EDL_DEVICE = 0x9008;
 class EdlDevice {
 	constructor({ serialNumber }) {
 		this.serialNumber = serialNumber;
+		this.id = this._computeDeviceId();
+	}
+
+	_computeDeviceId() {
+		// Assume all EDL devices are Tachyons and use the SOC machine ID type
+		const platformId = deviceConstants.tachyon.id;
+		const machineIdType = deviceConstants.linux.machineIdTypes.SOC;
+		const platformAndMachineIdType = Buffer.from([platformId, machineIdType]).toString('hex');
+		const suffix = this.serialNumber.toLowerCase().substring(0, 18).padStart(18, '0');
+		return `42${platformAndMachineIdType}${suffix}`;
 	}
 
 	static async getEdlDevices() {


### PR DESCRIPTION
Calculate Tachyon device ID in EDL mode with the same algorithm as API.

Assume all EDL devices are Tachyons and that the EDL serial number is the System On Chip serial number. This will create device ID 422a060000000000 followed by the EDL serial number in lower case.