### PR TITLE
Add USB version to EDL devices

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,12 @@ jobs:
         experimental:
           - false
         node_version:
-          - 12
-          - 14
           - 16
+          - 22
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
           node-version: ${{ matrix.node_version }}

--- a/src/edl-device.js
+++ b/src/edl-device.js
@@ -5,9 +5,10 @@ const VENDOR_ID_QUALCOMM = 0x05c6;
 const PRODUCT_ID_EDL_DEVICE = 0x9008;
 
 class EdlDevice {
-	constructor({ serialNumber }) {
+	constructor({ serialNumber, usbVersion }) {
 		this.serialNumber = serialNumber;
 		this.id = this._computeDeviceId();
+		this.usbVersion = usbVersion;
 	}
 
 	_computeDeviceId() {
@@ -31,7 +32,7 @@ class EdlDevice {
 			try {
 				await dev.open();
 				const serialNumber = dev.productName.replace(/.*_SN:/, '');
-				return new EdlDevice({ serialNumber });
+				return new EdlDevice({ serialNumber, usbVersion: dev.usbVersion });
 			} finally {
 				dev.close();
 			}

--- a/src/usb-device-node.js
+++ b/src/usb-device-node.js
@@ -224,6 +224,11 @@ class UsbDevice {
 	set quirks(qs) {
 		this._quirks = qs;
 	}
+
+	get usbVersion() {
+		const version = this._dev.deviceDescriptor.bcdUSB;
+		return { major: version >> 8, minor: (version & 0xff) >> 4 };
+	}
 }
 
 async function getUsbDevices(filters) {


### PR DESCRIPTION
Process the bcdUSB field from the device descriptor to expose the USB version. Mapping looks like 0x200 for USB 2.0, 0x210 for USB 2.1, 0x300 for USB 3.0, 0x320 for USB 3.2.

Will be used by CLI to say the Tachyon flash is slow unless the major USB version is 3 or later.